### PR TITLE
Authentication feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+Build/
+ProseCore/ProseCore/ProseCore.xcframework

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+RUST_LIB_PATH = ../uniffi_test
+RUST_LIB_NAME = uniffi_test
+SWIFT_LIB_NAME = ProseCore
+BUILD_FOLDER = Build
+
+all: interface framework
+
+interface:
+	uniffi-bindgen generate $(RUST_LIB_PATH)/src/$(RUST_LIB_NAME).udl -o ./$(BUILD_FOLDER)/interface --language swift
+	sed -i '' 's/import uniffi_testFFI/@_implementationOnly import uniffi_testFFI/g' ./$(BUILD_FOLDER)/interface/$(RUST_LIB_NAME).swift
+
+framework:
+	rm -f $(BUILD_FOLDER)/lib$(SWIFT_LIB_NAME).a
+	rm -f $(BUILD_FOLDER)/$(SWIFT_LIB_NAME).a
+	rm -f $(BUILD_FOLDER)/$(SWIFT_LIB_NAME).swiftmodule
+	
+	(cd $(BUILD_FOLDER); swiftc \
+		-module-name $(SWIFT_LIB_NAME) \
+		-emit-library -o lib$(SWIFT_LIB_NAME).a \
+		-emit-module -emit-module-path . \
+		-parse-as-library \
+		-L $(RUST_LIB_PATH)/target/aarch64-apple-darwin/release \
+		-l$(RUST_LIB_NAME) \
+		-Xcc -fmodule-map-file=./interface/$(RUST_LIB_NAME)FFI.modulemap \
+		-static \
+		-enable-library-evolution \
+		./interface/$(RUST_LIB_NAME).swift)
+	
+	libtool -static -o $(BUILD_FOLDER)/$(SWIFT_LIB_NAME).a $(BUILD_FOLDER)/lib$(SWIFT_LIB_NAME).a $(RUST_LIB_PATH)/target/aarch64-apple-darwin/release/lib$(RUST_LIB_NAME).a
+	
+	rm -rf ProseCore/ProseCore/$(SWIFT_LIB_NAME).xcframework
+	
+	xcodebuild -create-xcframework \
+		-library ./Build/$(SWIFT_LIB_NAME).a \
+		-output ProseCore/ProseCore/$(SWIFT_LIB_NAME).xcframework
+	
+	cp Build/$(SWIFT_LIB_NAME).swiftmodule ProseCore/ProseCore/$(SWIFT_LIB_NAME).xcframework/macos-arm64

--- a/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "4cf088c29a20f52be0f2ca54992b492c54e0076b",
+        "version" : "0.5.3"
+      }
+    },
+    {
       "identity" : "preferences",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Preferences",
@@ -10,12 +19,57 @@
       }
     },
     {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "241301b67d8551c26d8f09bd2c0e52cc49f18007",
+        "version" : "0.8.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "48254824bb4248676bf7ce56014ff57b142b77eb",
         "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "2828dc44f6e3f81d84bcaba72c1ab1c0121d66f6",
+        "version" : "0.34.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "680bf440178a78a627b1c2c64c0855f6523ad5b9",
+        "version" : "0.3.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
+        "version" : "0.2.1"
       }
     }
   ],

--- a/Prose/Prose.xcodeproj/xcshareddata/xcschemes/Prose.xcscheme
+++ b/Prose/Prose.xcodeproj/xcshareddata/xcschemes/Prose.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52EA116D274C23C2007DA1C5"
+               BuildableName = "Prose.app"
+               BlueprintName = "Prose"
+               ReferencedContainer = "container:Prose.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "52EA116D274C23C2007DA1C5"
+            BuildableName = "Prose.app"
+            BlueprintName = "Prose"
+            ReferencedContainer = "container:Prose.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "52EA116D274C23C2007DA1C5"
+            BuildableName = "Prose.app"
+            BlueprintName = "Prose"
+            ReferencedContainer = "container:Prose.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
     .package(url: "https://github.com/sindresorhus/Preferences", .upToNextMajor(from: "2.5.0")),
     .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.2")),
     .package(
-      name: "swift-composable-architecture",
       url: "https://github.com/pointfreeco/swift-composable-architecture",
       .upToNextMajor(from: "0.33.1")
     ),

--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -13,13 +13,33 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/sindresorhus/Preferences", .upToNextMajor(from: "2.5.0")),
     .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.2")),
+    .package(
+      name: "swift-composable-architecture",
+      url: "https://github.com/pointfreeco/swift-composable-architecture",
+      .upToNextMajor(from: "0.33.1")
+    ),
   ],
   targets: [
-    .target(name: "App", dependencies: ["SettingsFeature", "SidebarFeature"]),
+    .target(
+      name: "App",
+      dependencies: [
+        "SettingsFeature",
+        "SidebarFeature",
+        "AuthenticationFeature",
+        "TcaHelpers",
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+      ]
+    ),
     .target(name: "Assets"),
     .target(name: "PreviewAssets"),
     .target(name: "ProseUI", dependencies: ["Assets", "PreviewAssets", "SharedModels"]),
     .target(name: "SharedModels"),
+    .target(
+      name: "TcaHelpers",
+      dependencies: [
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+      ]
+    ),
     .target(name: "SettingsFeature", dependencies: ["Preferences", "Assets", "ProseUI"]),
     .target(
       name: "SidebarFeature",
@@ -32,6 +52,12 @@ let package = Package(
         "ProseUI",
         "PreviewAssets",
         .product(name: "OrderedCollections", package: "swift-collections"),
+      ]
+    ),
+    .target(
+      name: "AuthenticationFeature",
+      dependencies: [
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
       ]
     ),
   ]

--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -5,12 +5,13 @@ import PackageDescription
 let package = Package(
   name: "ProseLib",
   defaultLocalization: "en",
-  platforms: [.iOS(.v15), .macOS(.v12)],
+  platforms: [.macOS(.v12)],
   products: [
     .library(name: "App", targets: ["App"]),
     .library(name: "ProseUI", targets: ["ProseUI"]),
   ],
   dependencies: [
+    .package(path: "../../ProseCore"),
     .package(url: "https://github.com/sindresorhus/Preferences", .upToNextMajor(from: "2.5.0")),
     .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.2")),
     .package(
@@ -26,6 +27,7 @@ let package = Package(
         "SidebarFeature",
         "AuthenticationFeature",
         "TcaHelpers",
+        "ProseCore",
         .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
       ]
     ),
@@ -42,7 +44,14 @@ let package = Package(
     .target(name: "SettingsFeature", dependencies: ["Preferences", "Assets", "ProseUI"]),
     .target(
       name: "SidebarFeature",
-      dependencies: ["Assets", "ProseUI", "PreviewAssets", "ConversationFeature"]
+      dependencies: [
+        "Assets",
+        "ProseUI",
+        "PreviewAssets",
+        "ConversationFeature",
+        "ProseCore",
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+      ]
     ),
     .target(
       name: "ConversationFeature",
@@ -56,6 +65,8 @@ let package = Package(
     .target(
       name: "AuthenticationFeature",
       dependencies: [
+        "ProseCore",
+        "SharedModels",
         .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
       ]
     ),

--- a/Prose/ProseLib/Sources/App/AppReducer.swift
+++ b/Prose/ProseLib/Sources/App/AppReducer.swift
@@ -1,0 +1,48 @@
+import AuthenticationFeature
+import ComposableArchitecture
+import Foundation
+
+struct AppState: Equatable {
+  var route: Route = .auth(AuthenticationState())
+}
+
+extension AppState {
+  enum Route: Equatable {
+    case auth(AuthenticationState)
+    case main
+  }
+}
+
+enum AppAction {
+  case auth(AuthenticationAction)
+}
+
+struct AppEnvironment {
+  static func live() -> Self {
+    .init()
+  }
+}
+
+extension AppEnvironment {
+  var auth: AuthenticationEnvironment {
+    AuthenticationEnvironment()
+  }
+}
+
+let appReducer = Reducer.combine(
+  authenticationReducer._pullback(
+    state: (\AppState.route).case(/AppState.Route.auth),
+    action: /AppAction.auth,
+    environment: \.auth
+  ),
+  Reducer<AppState, AppAction, AppEnvironment> { state, action, _ in
+    switch action {
+    case .auth(.loginButtonTapped):
+      state.route = .main
+      return .none
+
+    case .auth:
+      return .none
+    }
+  }
+)

--- a/Prose/ProseLib/Sources/App/AppView.swift
+++ b/Prose/ProseLib/Sources/App/AppView.swift
@@ -7,8 +7,6 @@ import TcaHelpers
 public struct AppView: View {
   private let store: Store<AppState, AppAction>
 
-  @State var selection: SidebarID? = .unread
-
   public init() {
     self.store = Store(
       initialState: AppState(),
@@ -32,12 +30,20 @@ public struct AppView: View {
         )
 
       case .main:
-        NavigationView {
-          SidebarView(selection: $selection)
-            .frame(minWidth: 280.0)
-          Text("Nothing to show here 🤷")
-        }
-        .listStyle(SidebarListStyle())
+        IfLetStore(
+          self.store.scope(
+            state: (\AppState.route).case(/AppState.Route.main),
+            action: AppAction.main
+          ),
+          then: { store in
+            NavigationView {
+              SidebarView(store: store)
+                .frame(minWidth: 280.0)
+              Text("Nothing to show here 🤷")
+            }
+            .listStyle(SidebarListStyle())
+          }
+        )
       }
     }
     .frame(minWidth: 1280, minHeight: 720)

--- a/Prose/ProseLib/Sources/App/AppView.swift
+++ b/Prose/ProseLib/Sources/App/AppView.swift
@@ -1,33 +1,45 @@
-//
-//  BaseView.swift
-//  Prose
-//
-//  Created by Valerian Saliou on 9/14/21.
-//
-
+import AuthenticationFeature
+import ComposableArchitecture
 import SidebarFeature
 import SwiftUI
+import TcaHelpers
 
 public struct AppView: View {
-    @State var selection: SidebarID? = .unread
-    
-    public init() {}
-    
-    public var body: some View {
+  private let store: Store<AppState, AppAction>
+
+  @State var selection: SidebarID? = .unread
+
+  public init() {
+    self.store = Store(
+      initialState: AppState(),
+      reducer: appReducer,
+      environment: .live()
+    )
+  }
+
+  public var body: some View {
+    WithViewStore(self.store) { viewStore in
+      switch viewStore.route {
+      case .auth:
+        IfLetStore(
+          self.store.scope(
+            state: (\AppState.route).case(/AppState.Route.auth),
+            action: AppAction.auth
+          ),
+          then: { store in
+            AuthenticationView(store: store)
+          }
+        )
+
+      case .main:
         NavigationView {
-            SidebarView(selection: $selection)
-                .frame(minWidth: 280.0)
-            Text("Nothing to show here 🤷")
+          SidebarView(selection: $selection)
+            .frame(minWidth: 280.0)
+          Text("Nothing to show here 🤷")
         }
         .listStyle(SidebarListStyle())
-        .frame(minWidth: 1280, minHeight: 720)
+      }
     }
-}
-
-struct AppView_Previews: PreviewProvider {
-    static var previews: some View {
-        Group {
-            AppView()
-        }
-    }
+    .frame(minWidth: 1280, minHeight: 720)
+  }
 }

--- a/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationReducer.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationReducer.swift
@@ -1,0 +1,35 @@
+import ComposableArchitecture
+import Foundation
+
+public struct AuthenticationState: Equatable {
+  @BindableState var email = "test@example.com"
+  @BindableState var password = "topsecret"
+
+  var isFormValid = true
+
+  public init() {}
+}
+
+public enum AuthenticationAction: BindableAction, Equatable {
+  case binding(BindingAction<AuthenticationState>)
+  case loginButtonTapped
+}
+
+public struct AuthenticationEnvironment {
+  public init() {}
+}
+
+public let authenticationReducer = Reducer<
+  AuthenticationState,
+  AuthenticationAction,
+  AuthenticationEnvironment
+> { state, action, _ in
+  switch action {
+  case .binding:
+    state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
+    return .none
+
+  case .loginButtonTapped:
+    return .none
+  }
+}.binding()

--- a/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationReducer.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationReducer.swift
@@ -1,10 +1,14 @@
+import Combine
 import ComposableArchitecture
 import Foundation
+import ProseCore
+import SharedModels
 
 public struct AuthenticationState: Equatable {
-  @BindableState var email = "test@example.com"
-  @BindableState var password = "topsecret"
+  @BindableState var jid = "hello@prose.org"
+  @BindableState var password = "password"
 
+  var alert: AlertState<AuthenticationAction>?
   var isFormValid = true
 
   public init() {}
@@ -12,24 +16,44 @@ public struct AuthenticationState: Equatable {
 
 public enum AuthenticationAction: BindableAction, Equatable {
   case binding(BindingAction<AuthenticationState>)
+  case alertDismissed
   case loginButtonTapped
+  case loginResult(Result<UserCredentials, EquatableError>)
 }
 
 public struct AuthenticationEnvironment {
-  public init() {}
+  var login: (String, String, ClientOrigin) -> Effect<Result<UserCredentials, EquatableError>, Never>
+
+  public init(login: @escaping (String, String, ClientOrigin)
+    -> Effect<Result<UserCredentials, EquatableError>, Never>)
+  {
+    self.login = login
+  }
 }
 
 public let authenticationReducer = Reducer<
   AuthenticationState,
   AuthenticationAction,
   AuthenticationEnvironment
-> { state, action, _ in
+> { state, action, environment in
   switch action {
   case .binding:
-    state.isFormValid = !state.email.isEmpty && !state.password.isEmpty
+    state.isFormValid = !state.jid.isEmpty && !state.password.isEmpty
+    return .none
+
+  case .alertDismissed:
+    state.alert = nil
     return .none
 
   case .loginButtonTapped:
+    return environment.login(state.jid, state.password, .proseAppMacOs)
+      .map(AuthenticationAction.loginResult)
+
+  case let .loginResult(.success(credentials)):
+    return .none
+
+  case let .loginResult(.failure(error)):
+    state.alert = .init(title: .init(error.localizedDescription))
     return .none
   }
 }.binding()

--- a/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationView.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationView.swift
@@ -1,0 +1,31 @@
+import ComposableArchitecture
+import SwiftUI
+
+public struct AuthenticationView: View {
+  public typealias State = AuthenticationState
+  public typealias Action = AuthenticationAction
+
+  let store: Store<State, Action>
+
+  public init(store: Store<State, Action>) {
+    self.store = store
+  }
+
+  public var body: some View {
+    WithViewStore(self.store) { viewStore in
+      HStack {
+        Spacer()
+        Form {
+          Section {
+            TextField("Email", text: viewStore.binding(\.$email))
+            SecureField("Password", text: viewStore.binding(\.$password))
+          }
+          Button("Login") {
+            viewStore.send(.loginButtonTapped)
+          }.disabled(!viewStore.isFormValid)
+        }.frame(maxWidth: 500)
+        Spacer()
+      }
+    }
+  }
+}

--- a/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationView.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationView.swift
@@ -17,7 +17,7 @@ public struct AuthenticationView: View {
         Spacer()
         Form {
           Section {
-            TextField("Email", text: viewStore.binding(\.$email))
+            TextField("Jid", text: viewStore.binding(\.$jid))
             SecureField("Password", text: viewStore.binding(\.$password))
           }
           Button("Login") {
@@ -26,6 +26,7 @@ public struct AuthenticationView: View {
         }.frame(maxWidth: 500)
         Spacer()
       }
+      .alert(self.store.scope(state: \.alert), dismiss: .alertDismissed)
     }
   }
 }

--- a/Prose/ProseLib/Sources/SharedModels/EquatableError+ProseCore.swift
+++ b/Prose/ProseLib/Sources/SharedModels/EquatableError+ProseCore.swift
@@ -1,0 +1,15 @@
+import Foundation
+import ProseCore
+
+extension LoginError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case let .NoSuchUser(message):
+      return message
+    case let .InvalidCredentials(message):
+      return message
+    @unknown default:
+      return "Unknown error"
+    }
+  }
+}

--- a/Prose/ProseLib/Sources/SharedModels/EquatableError.swift
+++ b/Prose/ProseLib/Sources/SharedModels/EquatableError.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+// Source: https://twittemb.github.io/posts/2021-12-10-EquatableError/
+public struct EquatableError: LocalizedError, Hashable, CustomStringConvertible {
+  public let base: Error
+
+  private let equals: (Error) -> Bool
+  private let hash: (inout Hasher) -> Void
+
+  public init<Base: Error>(_ base: Base) {
+    self.base = base
+    self.equals = { String(reflecting: $0) == String(reflecting: base) }
+    self.hash = { $0.combine(String(reflecting: base)) }
+  }
+
+  public init<Base: Error & Equatable>(_ base: Base) {
+    self.base = base
+    self.equals = { ($0 as? Base) == base }
+    self.hash = { $0.combine(String(reflecting: base)) }
+  }
+
+  public init<Base: Error & Hashable>(_ base: Base) {
+    self.base = base
+    self.equals = { ($0 as? Base) == base }
+    self.hash = base.hash(into:)
+  }
+
+  public static func == (lhs: EquatableError, rhs: EquatableError) -> Bool {
+    lhs.equals(rhs.base)
+  }
+
+  public var description: String {
+    "\(self.base)"
+  }
+
+  public var localizedDescription: String {
+    print(self.base)
+    return self.base.localizedDescription
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    self.hash(&hasher)
+  }
+}
+
+public extension Error where Self: Hashable {
+  func eraseToEquatableError() -> EquatableError {
+    EquatableError(self)
+  }
+}
+
+public extension Error where Self: Equatable {
+  func eraseToEquatableError() -> EquatableError {
+    EquatableError(self)
+  }
+}
+
+public extension Error {
+  func eraseToEquatableError() -> EquatableError {
+    EquatableError(self)
+  }
+}

--- a/Prose/ProseLib/Sources/SidebarFeature/Sidebar+Footer.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Sidebar+Footer.swift
@@ -5,12 +5,14 @@
 //  Created by Valerian Saliou on 11/28/21.
 //
 
+import ComposableArchitecture
 import PreviewAssets
 import SwiftUI
 
 extension SidebarView {
     
     struct Footer: View {
+        let store: Store<SidebarState, SidebarAction>
         
         let avatar: String = PreviewImages.Avatars.valerian.rawValue
         let teamName: String = "Crisp"
@@ -18,44 +20,38 @@ extension SidebarView {
         let statusMessage: String = "Building new features."
         
         var body: some View {
-            VStack(spacing: 0) {
-                Divider()
-                
-                HStack(spacing: 12) {
-                    // User avatar
-                    SidebarFooterAvatar(
-                        avatar: avatar,
-                        status: .online
-                    )
+            WithViewStore(self.store) { viewStore in
+                VStack(spacing: 0) {
+                    Divider()
                     
-                    // Team name + user status
-                    SidebarFooterDetails(
-                        teamName: teamName,
-                        statusIcon: statusIcon,
-                        statusMessage: statusMessage
-                    )
-                    .layoutPriority(1)
-                    
-                    Spacer()
-                    
-                    // Quick action button
-                    SidebarFooterActionButton()
+                    HStack(spacing: 12) {
+                        // User avatar
+                        SidebarFooterAvatar(
+                            avatar: avatar,
+                            status: .online
+                        )
+                        
+                        // Team name + user status
+                        SidebarFooterDetails(
+                            teamName: viewStore.credentials.jid,
+                            statusIcon: statusIcon,
+                            statusMessage: statusMessage
+                        )
+                        .layoutPriority(1)
+                        
+                        Spacer()
+                        
+                        // Quick action button
+                        SidebarFooterActionButton()
+                    }
+                    .padding(.leading, 20.0)
+                    .padding(.trailing, 14.0)
+                    .frame(maxHeight: 64)
                 }
-                .padding(.leading, 20.0)
-                .padding(.trailing, 14.0)
-                .frame(maxHeight: 64)
+                .frame(height: 64)
             }
-            .frame(height: 64)
         }
         
-    }
-    
-}
-
-struct SidebarPartContextComponent_Previews: PreviewProvider {
-    
-    static var previews: some View {
-        SidebarView.Footer()
     }
     
 }

--- a/Prose/ProseLib/Sources/SidebarFeature/SidebarReducer.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/SidebarReducer.swift
@@ -1,0 +1,32 @@
+import ComposableArchitecture
+import Foundation
+import ProseCore
+
+public struct SidebarState: Equatable {
+  var credentials: UserCredentials
+  
+  @BindableState var selection: SidebarID? = .unread
+  
+  public init(credentials: UserCredentials) {
+    self.credentials = credentials
+  }
+}
+
+public enum SidebarAction: BindableAction {
+  case binding(BindingAction<SidebarState>)
+}
+
+public struct SidebarEnvironment {
+  public init() {}
+}
+
+public let sidebarReducer = Reducer<
+  SidebarState,
+  SidebarAction,
+  SidebarEnvironment
+> { state, action, _ in
+  switch action {
+  case .binding:
+    return .none
+  }
+}.binding()

--- a/Prose/ProseLib/Sources/SidebarFeature/SidebarView.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/SidebarView.swift
@@ -5,28 +5,26 @@
 //  Created by Valerian Saliou on 11/15/21.
 //
 
+import ComposableArchitecture
 import SwiftUI
 
 public struct SidebarView: View {
-    @Binding var selection: SidebarID?
+    public typealias State = SidebarState
+    public typealias Action = SidebarAction
     
-    public init(selection: Binding<SidebarID?>) {
-      self._selection = selection
+    let store: Store<State, Action>
+    
+    public init(store: Store<State, Action>) {
+        self.store = store
     }
     
     public var body: some View {
-        VStack(spacing: 0) {
-            Content(selection: $selection)
-            Footer()
+        WithViewStore(self.store) { viewStore in
+            VStack(spacing: 0) {
+                Content(selection: viewStore.binding(\.$selection))
+                Footer(store: self.store)
+            }
+            .toolbar(content: SidebarToolbar.init)
         }
-        .toolbar(content: SidebarToolbar.init)
-    }
-}
-
-struct SidebarView_Previews: PreviewProvider {
-    static var previews: some View {
-        SidebarView(
-            selection: .constant(nil)
-        )
     }
 }

--- a/Prose/ProseLib/Sources/TcaHelpers/OptionalPaths.swift
+++ b/Prose/ProseLib/Sources/TcaHelpers/OptionalPaths.swift
@@ -1,0 +1,238 @@
+import ComposableArchitecture
+
+public protocol Path {
+  associatedtype Root
+  associatedtype Value
+  func extract(from root: Root) -> Value?
+  func set(into root: inout Root, _ value: Value)
+}
+
+extension WritableKeyPath: Path {
+  public func extract(from root: Root) -> Value? {
+    root[keyPath: self]
+  }
+
+  public func set(into root: inout Root, _ value: Value) {
+    root[keyPath: self] = value
+  }
+}
+
+extension CasePath: Path {
+  public func set(into root: inout Root, _ value: Value) {
+    root = self.embed(value)
+  }
+}
+
+public struct OptionalPath<Root, Value>: Path {
+  private let _extract: (Root) -> Value?
+  private let _set: (inout Root, Value) -> Void
+
+  public init(
+    extract: @escaping (Root) -> Value?,
+    set: @escaping (inout Root, Value) -> Void
+  ) {
+    self._extract = extract
+    self._set = set
+  }
+
+  public func extract(from root: Root) -> Value? {
+    self._extract(root)
+  }
+
+  public func set(into root: inout Root, _ value: Value) {
+    self._set(&root, value)
+  }
+
+  public init(
+    _ keyPath: WritableKeyPath<Root, Value?>
+  ) {
+    self.init(
+      extract: { $0[keyPath: keyPath] },
+      set: { $0[keyPath: keyPath] = $1 }
+    )
+  }
+
+  public init(
+    _ casePath: CasePath<Root, Value>
+  ) {
+    self.init(
+      extract: casePath.extract(from:),
+      set: { $0 = casePath.embed($1) }
+    )
+  }
+
+  public subscript<AppendedValue>(casePath: CasePath<Value, AppendedValue>)
+    -> OptionalPath<Root, AppendedValue>
+  {
+    self.appending(path: casePath)
+  }
+
+  public func appending<AppendedValue>(
+    path: OptionalPath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    .init(
+      extract: { self.extract(from: $0).flatMap(path.extract(from:)) },
+      set: { root, appendedValue in
+        guard var value = self.extract(from: root) else { return }
+        path.set(into: &value, appendedValue)
+        self.set(into: &root, value)
+      }
+    )
+  }
+
+  public func appending<AppendedValue>(
+    path: CasePath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    self.appending(path: .init(path))
+  }
+
+  public func appending<AppendedValue>(
+    path: WritableKeyPath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    .init(
+      extract: { self.extract(from: $0).map { $0[keyPath: path] } },
+      set: { root, appendedValue in
+        guard var value = self.extract(from: root) else { return }
+        value[keyPath: path] = appendedValue
+        self.set(into: &root, value)
+      }
+    )
+  }
+
+  // TODO: Is it safe to keep this overload?
+  public func appending<AppendedValue>(
+    path: WritableKeyPath<Value, AppendedValue?>
+  ) -> OptionalPath<Root, AppendedValue> {
+    self.appending(path: .init(path))
+  }
+}
+
+public extension CasePath {
+  func appending<AppendedValue>(
+    path: OptionalPath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    OptionalPath(self).appending(path: path)
+  }
+
+  func appending<AppendedValue>(
+    path: WritableKeyPath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    OptionalPath(self).appending(path: path)
+  }
+
+  // TODO: Is it safe to keep this overload?
+  func appending<AppendedValue>(
+    path: WritableKeyPath<Value, AppendedValue?>
+  ) -> OptionalPath<Root, AppendedValue> {
+    OptionalPath(self).appending(path: path)
+  }
+}
+
+public extension WritableKeyPath {
+  func appending<AppendedValue>(
+    path: OptionalPath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    OptionalPath(
+      extract: { path.extract(from: $0[keyPath: self]) },
+      set: { root, appendedValue in path.set(into: &root[keyPath: self], appendedValue) }
+    )
+  }
+
+  func appending<AppendedValue>(
+    path: CasePath<Value, AppendedValue>
+  ) -> OptionalPath<Root, AppendedValue> {
+    self.appending(path: .init(path))
+  }
+}
+
+public extension WritableKeyPath {
+  func `case`<Case>(_ casePath: CasePath<Value, Case>) -> OptionalPath<Root, Case> {
+    self.appending(path: casePath)
+  }
+}
+
+public extension OptionalPath where Root == Value {
+  static var `self`: OptionalPath {
+    .init(.self)
+  }
+}
+
+public extension OptionalPath where Root == Value? {
+  static var some: OptionalPath {
+    .init(/Optional.some)
+  }
+}
+
+public extension Reducer {
+  func _pullback<GlobalState, GlobalAction, GlobalEnvironment, StatePath, ActionPath>(
+    state toLocalState: StatePath,
+    action toLocalAction: ActionPath,
+    environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment,
+    breakpointOnNil: Bool = true,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
+    where
+    StatePath: Path, StatePath.Root == GlobalState, StatePath.Value == State,
+    ActionPath: Path, ActionPath.Root == GlobalAction, ActionPath.Value == Action
+  {
+    .init { globalState, globalAction, globalEnvironment in
+
+      guard let localAction = toLocalAction.extract(from: globalAction)
+      else { return .none }
+
+      guard var localState = toLocalState.extract(from: globalState)
+      else {
+        #if DEBUG
+          if breakpointOnNil {
+            fputs(
+              """
+              ---
+              Warning: Reducer._pullback@\(file):\(line)
+
+              "\(globalAction)" was received by an optional reducer when its state was \
+              "nil". This can happen for a few reasons:
+
+              * The optional reducer was combined with or run from another reducer that set \
+              "\(State.self)" to "nil" before the optional reducer ran. Combine or run optional \
+              reducers before reducers that can set their state to "nil". This ensures that \
+              optional reducers can handle their actions while their state is still non-"nil".
+
+              * An active effect emitted this action while state was "nil". Make sure that effects
+              for this optional reducer are canceled when optional state is set to "nil".
+
+              * This action was sent to the store while state was "nil". Make sure that actions \
+              for this reducer can only be sent to a view store when state is non-"nil". In \
+              SwiftUI applications, use "IfLetStore".
+              ---
+
+              """,
+              stderr
+            )
+            raise(SIGTRAP)
+          }
+        #endif
+        return .none
+      }
+
+      let effect =
+        self.run(&localState, localAction, toLocalEnvironment(globalEnvironment))
+          .map { localAction -> GlobalAction in
+            var globalAction = globalAction
+            toLocalAction.set(into: &globalAction, localAction)
+            return globalAction
+          }
+      toLocalState.set(into: &globalState, localState)
+      return effect
+    }
+  }
+}
+
+public extension Store {
+  func scope<LocalState, LocalAction>(
+    state path: OptionalPath<State, LocalState>,
+    action fromLocalAction: @escaping (LocalAction) -> Action
+  ) -> Store<LocalState?, LocalAction> {
+    self.scope(state: path.extract(from:), action: fromLocalAction)
+  }
+}

--- a/ProseCore/Package.swift
+++ b/ProseCore/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+  name: "ProseCore",
+  platforms: [.iOS(.v13)],
+  products: [
+    .library(name: "ProseCore", targets: ["ProseCore"]),
+  ],
+  targets: [
+    .binaryTarget(
+      name: "ProseCore",
+      path: "ProseCore/ProseCore.xcframework"
+    ),
+  ]
+)


### PR DESCRIPTION
This PR adds a very basic login screen that uses the [composable architecture](https://github.com/pointfreeco/swift-composable-architecture) (TCA) for state management.

For verifying the credentials (this is just a static check ATM) the app calls into a Rust library via [UniFFI](https://mozilla.github.io/uniffi-rs/), which was the primary goal. I couldn't get the prose-core-client to compile, so I created a [small project for testing](https://github.com/nesium/uniffi_test). I've added a script which builds the Rust library and code generated by UniFFI into a XCFramework. Currently the script only builds the slice for M1 Macs and is most likely not the best way to do it, but one problem at a time.

As mentioned the main intent for this PR is to get the ball rolling so that we can figure out how we want to integrate the Rust library within the app and communicate between the two.

To try:
1. Install uniffi-bindgen (`$ cargo install uniffi_bindgen`)
2. Checkout [uniffi_test](https://github.com/nesium/uniffi_test) next to the prose-app-macos folder.
3. Build the Rust library by changing into the uniffi_test directory and running `$ make`.
4. Build the XCFramework by changing into the prose-app-macos folder and running `$ make`.
5. Build and run the app in Xcode.
6. You'll see a login form with prefilled data. You can login by clicking the Login button with that data and will see the jid returned from Rust in the sidebar footer. If you set the Jid to anything other than "hello@prose.org", you'll see the error thrown from Rust "The user does not exist" after tapping the Login button. If you change the password to anything other than "password" you'll see an error "Invalid credentials".