### PR TITLE
Disable authentication feature

### DIFF
--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .library(name: "ProseUI", targets: ["ProseUI"]),
   ],
   dependencies: [
-    .package(path: "../../ProseCore"),
+    //.package(path: "../../ProseCore"),
     .package(url: "https://github.com/sindresorhus/Preferences", .upToNextMajor(from: "2.5.0")),
     .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.2")),
     .package(
@@ -25,9 +25,9 @@ let package = Package(
       dependencies: [
         "SettingsFeature",
         "SidebarFeature",
-        "AuthenticationFeature",
+        //"AuthenticationFeature",
         "TcaHelpers",
-        "ProseCore",
+        //"ProseCore",
         .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
       ]
     ),
@@ -49,7 +49,7 @@ let package = Package(
         "ProseUI",
         "PreviewAssets",
         "ConversationFeature",
-        "ProseCore",
+        //"ProseCore",
         .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
       ]
     ),
@@ -62,13 +62,13 @@ let package = Package(
         .product(name: "OrderedCollections", package: "swift-collections"),
       ]
     ),
-    .target(
-      name: "AuthenticationFeature",
-      dependencies: [
-        "ProseCore",
-        "SharedModels",
-        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
-      ]
-    ),
+//    .target(
+//      name: "AuthenticationFeature",
+//      dependencies: [
+//        //"ProseCore",
+//        "SharedModels",
+//        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+//      ]
+//    ),
   ]
 )

--- a/Prose/ProseLib/Sources/App/AppReducer.swift
+++ b/Prose/ProseLib/Sources/App/AppReducer.swift
@@ -1,12 +1,15 @@
-import AuthenticationFeature
+//import AuthenticationFeature
 import ComposableArchitecture
 import Foundation
-import ProseCore
+//import ProseCore
 import SharedModels
 import SidebarFeature
 
+public struct AuthenticationState: Equatable {}
+public enum AuthenticationAction: Equatable {}
+
 struct AppState: Equatable {
-  var route: Route = .auth(AuthenticationState())
+  var route: Route = .main(SidebarState(credentials: .init(jid: "Hello World")))
 }
 
 extension AppState {
@@ -28,15 +31,15 @@ struct AppEnvironment {
 }
 
 extension AppEnvironment {
-  var auth: AuthenticationEnvironment {
-    .init(login: { jid, password, origin in
-      Effect.catching {
-        try ProseCore.login(jid: jid, password: password, origin: origin)
-      }
-      .mapError(EquatableError.init)
-      .catchToEffect()
-    })
-  }
+//  var auth: AuthenticationEnvironment {
+//    .init(login: { jid, password, origin in
+//      Effect.catching {
+//        try ProseCore.login(jid: jid, password: password, origin: origin)
+//      }
+//      .mapError(EquatableError.init)
+//      .catchToEffect()
+//    })
+//  }
 
   var main: SidebarEnvironment {
     .init()
@@ -44,11 +47,11 @@ extension AppEnvironment {
 }
 
 let appReducer = Reducer.combine(
-  authenticationReducer._pullback(
-    state: (\AppState.route).case(/AppState.Route.auth),
-    action: /AppAction.auth,
-    environment: \.auth
-  ),
+//  authenticationReducer._pullback(
+//    state: (\AppState.route).case(/AppState.Route.auth),
+//    action: /AppAction.auth,
+//    environment: \.auth
+//  ),
   sidebarReducer._pullback(
     state: (\AppState.route).case(/AppState.Route.main),
     action: /AppAction.main,
@@ -56,10 +59,6 @@ let appReducer = Reducer.combine(
   ),
   Reducer<AppState, AppAction, AppEnvironment> { state, action, _ in
     switch action {
-    case let .auth(.loginResult(.success(credentials))):
-      state.route = .main(SidebarState(credentials: credentials))
-      return .none
-
     case .auth, .main:
       return .none
     }

--- a/Prose/ProseLib/Sources/App/AppView.swift
+++ b/Prose/ProseLib/Sources/App/AppView.swift
@@ -1,8 +1,16 @@
-import AuthenticationFeature
+//import AuthenticationFeature
 import ComposableArchitecture
 import SidebarFeature
 import SwiftUI
 import TcaHelpers
+
+struct AuthenticationView: View {
+  let store: Store<AuthenticationState, AuthenticationAction>
+
+  var body: some View {
+    Text("Implement me")
+  }
+}
 
 public struct AppView: View {
   private let store: Store<AppState, AppAction>

--- a/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationReducer.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationReducer.swift
@@ -1,7 +1,7 @@
 import Combine
 import ComposableArchitecture
 import Foundation
-import ProseCore
+//import ProseCore
 import SharedModels
 
 public struct AuthenticationState: Equatable {

--- a/Prose/ProseLib/Sources/SharedModels/EquatableError+ProseCore.swift
+++ b/Prose/ProseLib/Sources/SharedModels/EquatableError+ProseCore.swift
@@ -1,15 +1,15 @@
 import Foundation
-import ProseCore
-
-extension LoginError: LocalizedError {
-  public var errorDescription: String? {
-    switch self {
-    case let .NoSuchUser(message):
-      return message
-    case let .InvalidCredentials(message):
-      return message
-    @unknown default:
-      return "Unknown error"
-    }
-  }
-}
+//import ProseCore
+//
+//extension LoginError: LocalizedError {
+//  public var errorDescription: String? {
+//    switch self {
+//    case let .NoSuchUser(message):
+//      return message
+//    case let .InvalidCredentials(message):
+//      return message
+//    @unknown default:
+//      return "Unknown error"
+//    }
+//  }
+//}

--- a/Prose/ProseLib/Sources/SidebarFeature/SidebarReducer.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/SidebarReducer.swift
@@ -1,6 +1,14 @@
 import ComposableArchitecture
 import Foundation
-import ProseCore
+//import ProseCore
+
+public struct UserCredentials: Equatable {
+  public var jid: String
+
+  public init(jid: String) {
+    self.jid = jid
+  }
+}
 
 public struct SidebarState: Equatable {
   var credentials: UserCredentials


### PR DESCRIPTION
This commit disables the AuthenticationFeature so that we can remove the Rust dependencies until we found a way to build the XCFramework for at least ARM and x86 macs.