### PR TITLE
Fix chat display by using `safeAreaInset`

### DIFF
--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageBar/MessageBar.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageBar/MessageBar.swift
@@ -44,6 +44,9 @@ struct MessageBar: View {
         // TODO: [Rémi Bardon] Maybe add a material background here, to make it more beautiful with content going under
 //        .background(.ultraThinMaterial)
         .background(.background)
+        // Make sure accessibility frame is correct
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .contain)
     }
 
     @ViewBuilder

--- a/Prose/ProseLib/Sources/ConversationFeature/ChatWithMessageBar.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/ChatWithMessageBar.swift
@@ -13,15 +13,15 @@ struct ChatWithMessageBar: View {
     let chatViewModel: ChatViewModel
 
     var body: some View {
-        VStack(spacing: 0) {
-            Chat(model: chatViewModel)
-                .frame(maxWidth: .infinity)
-
-            MessageBar(
-                firstName: "Valerian"
-            )
-            .layoutPriority(1)
-        }
+        Chat(model: chatViewModel)
+            .frame(maxWidth: .infinity)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                MessageBar(
+                    firstName: "Valerian"
+                )
+                // Make footer have a higher priority, to be accessible over the scroll view
+                .accessibilitySortPriority(1)
+            }
     }
 }
 

--- a/Prose/ProseLib/Sources/ConversationFeature/ConversationDetailsView.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/ConversationDetailsView.swift
@@ -34,21 +34,21 @@ struct ConversationDetailsView: View {
 
     var body: some View {
         ScrollView(.vertical) {
-            VStack(spacing: 12) {
-                IdentitySection(
-                    avatar: avatar,
-                    name: name
-                )
-                QuickActionsSection()
-            }
-            .padding()
-            .frame(maxWidth: .infinity)
-
             VStack(spacing: 24) {
+                VStack(spacing: 12) {
+                    IdentitySection(
+                        avatar: avatar,
+                        name: name
+                    )
+                    QuickActionsSection()
+                }
+                .padding(.horizontal)
+
                 InformationSection()
                 SecuritySection()
                 ActionsSection()
             }
+            .padding(.vertical)
         }
         .groupBoxStyle(SectionGroupStyle())
         .background(.background)

--- a/Prose/ProseLib/Sources/ConversationFeature/ConversationScreen.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/ConversationScreen.swift
@@ -27,18 +27,18 @@ public struct ConversationScreen: View {
     }
 
     public var body: some View {
-        HStack(spacing: 0) {
-            ChatWithMessageBar(chatViewModel: chatViewModel)
-
-            Divider()
-
-            ConversationDetailsView(
-                avatar: sender.avatar,
-                name: sender.displayName
-            )
-            .frame(width: 220.0)
-        }
-        .toolbar(content: Toolbar.init)
+        ChatWithMessageBar(chatViewModel: chatViewModel)
+            .safeAreaInset(edge: .trailing, spacing: 0) {
+                HStack(spacing: 0) {
+                    Divider()
+                    ConversationDetailsView(
+                        avatar: sender.avatar,
+                        name: sender.displayName
+                    )
+                }
+                .frame(width: 220)
+            }
+            .toolbar(content: Toolbar.init)
     }
 }
 


### PR DESCRIPTION
Because of `HStack`s and `VStack`s, the chat screen wasn't interpreted correctly by SwiftUI (scroll under navigation bar and message bar). I fixed it by using `safeAreaInset`, like in the sidebar.

Also, I left

```swift
        // TODO: [Rémi Bardon] Maybe add a material background here, to make it more beautiful with content going under
//        .background(.ultraThinMaterial)
        .background(.background)
```

unchanged (in `MessageBar`), but I really think we should change the background, as it looks a lot better with a material background.