### PR TITLE
chore: Remove unnecessary `ViewBuilder`s (#26)

### DIFF
--- a/Prose/ProseLib/Sources/AddressBookFeature/Toolbar.swift
+++ b/Prose/ProseLib/Sources/AddressBookFeature/Toolbar.swift
@@ -23,7 +23,6 @@ struct Toolbar: ToolbarContent {
         }
     }
 
-    @ViewBuilder
     static func actions() -> some View {
         Group {
             Button { print("Add contact tapped") } label: {

--- a/Prose/ProseLib/Sources/ConversationFeature/MessageBar/MessageBar.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/MessageBar/MessageBar.swift
@@ -58,7 +58,6 @@ struct MessageBar: View {
         .accessibilityElement(children: .contain)
     }
 
-    @ViewBuilder
     private func leadingButtons() -> some View {
         HStack(spacing: 12) {
             Button(action: {}) {
@@ -70,7 +69,6 @@ struct MessageBar: View {
         .disabled(self.redactionReasons.contains(.placeholder))
     }
 
-    @ViewBuilder
     private func trailingButtons() -> some View {
         HStack(spacing: 12) {
             Button(action: {}) {

--- a/Prose/ProseLib/Sources/ConversationInfoFeature/Sections/IdentitySection.swift
+++ b/Prose/ProseLib/Sources/ConversationInfoFeature/Sections/IdentitySection.swift
@@ -43,7 +43,6 @@ struct IdentitySection: View {
         }
     }
 
-    @ViewBuilder
     private func avatar() -> some View {
         WithViewStore(self.store.scope(state: \State.avatar)) { avatar in
             if let imageName = avatar.state {

--- a/Prose/ProseLib/Sources/ConversationInfoFeature/Sections/InformationSection.swift
+++ b/Prose/ProseLib/Sources/ConversationInfoFeature/Sections/InformationSection.swift
@@ -46,7 +46,6 @@ struct InformationSection: View {
         }
     }
 
-    @ViewBuilder
     private func label(_ title: String, systemImage: String) -> some View {
         Label {
             Text(title)

--- a/Prose/ProseLib/Sources/ConversationInfoFeature/Sections/SecuritySection.swift
+++ b/Prose/ProseLib/Sources/ConversationInfoFeature/Sections/SecuritySection.swift
@@ -29,7 +29,6 @@ struct SecuritySection: View {
         }
     }
 
-    @ViewBuilder
     private func identityVerified() -> some View {
         HStack(spacing: 8) {
             WithViewStore(self.store.scope(state: \State.isIdentityVerified)) { isIdentityVerified in
@@ -53,7 +52,6 @@ struct SecuritySection: View {
         }
     }
 
-    @ViewBuilder
     private func encryption() -> some View {
         HStack(spacing: 8) {
             WithViewStore(self.store.scope(state: \State.encryptionFingerprint)) { fingerprint in
@@ -77,7 +75,6 @@ struct SecuritySection: View {
         }
     }
 
-    @ViewBuilder
     func infoButton(action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: "info.circle")

--- a/Prose/ProseLib/Sources/SettingsFeature/SettingsFormFieldComponent.swift
+++ b/Prose/ProseLib/Sources/SettingsFeature/SettingsFormFieldComponent.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsFormFieldComponent<Content: View>: View {
     var label: String
-    let viewBuilder: () -> Content
+    let content: () -> Content
 
     var body: some View {
         HStack {
@@ -17,7 +17,7 @@ struct SettingsFormFieldComponent<Content: View>: View {
                 label: label
             )
 
-            viewBuilder()
+            content()
         }
     }
 }

--- a/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterActionMenu.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterActionMenu.swift
@@ -50,15 +50,13 @@ struct FooterActionMenu: View {
         }
     }
 
-    @ViewBuilder
     private func popover() -> some View {
         Self.popover(store: self.store)
     }
 
-    @ViewBuilder
     fileprivate static func popover(store: Store<State, Action>) -> some View {
         let actions: ViewStore<Void, Action> = ViewStore(store.stateless)
-        VStack(alignment: .leading) {
+        return VStack(alignment: .leading) {
             // TODO: [Rémi Bardon] Refactor this view out
             HStack {
                 // TODO: [Rémi Bardon] Change this to Crisp icon

--- a/Prose/ProseLib/Sources/SidebarFeature/NavigationDestinationView.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/NavigationDestinationView.swift
@@ -29,7 +29,6 @@ struct NavigationDestinationView: View {
             .navigationTitle("")
     }
 
-    @ViewBuilder
     private func content() -> some View {
         SwitchStore(self.store) {
             CaseLet(state: /State.chat, action: Action.chat, then: ConversationScreen.init(store:))

--- a/Prose/ProseLib/Sources/UnreadFeature/UnreadScreen.swift
+++ b/Prose/ProseLib/Sources/UnreadFeature/UnreadScreen.swift
@@ -34,7 +34,6 @@ public struct UnreadScreen: View {
             .onAppear { actions.send(.onAppear) }
     }
 
-    @ViewBuilder
     private func content() -> some View {
         WithViewStore(self.store.scope(state: \State.messages.isEmpty)) { noMessage in
             if noMessage.state {
@@ -45,7 +44,6 @@ public struct UnreadScreen: View {
         }
     }
 
-    @ViewBuilder
     private func nothing() -> some View {
         Text("Looks like you read everything 🎉")
             .font(.largeTitle.bold())
@@ -54,7 +52,6 @@ public struct UnreadScreen: View {
             .unredacted()
     }
 
-    @ViewBuilder
     private func list() -> some View {
         ScrollView {
             VStack(spacing: 24) {
@@ -215,7 +212,6 @@ struct UnreadScreen_Previews: PreviewProvider {
             content(state: .init(messages: .init()))
         }
 
-        @ViewBuilder
         private func content(state: UnreadState) -> some View {
             UnreadScreen(store: Store(
                 initialState: state,


### PR DESCRIPTION
Closes #26.

There are only 3 `@ViewBuilder`s left, all required.