### PR TITLE
chore: Fix previews in Xcode 14

### DIFF
--- a/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Preferences",
       "state" : {
-        "revision" : "ffeaaad1def45d0625720dc1adae3789cd9c167d",
-        "version" : "2.5.0"
+        "revision" : "2651cd144615009242c994b087508fef99e9275c",
+        "version" : "2.6.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "241301b67d8551c26d8f09bd2c0e52cc49f18007",
-        "version" : "0.8.0"
+        "revision" : "b4a872984463070c71e2e97e5c02c73a07d0fe36",
+        "version" : "0.9.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "2828dc44f6e3f81d84bcaba72c1ab1c0121d66f6",
-        "version" : "0.34.0"
+        "revision" : "db890996189ca27da9e56f4cc82a70057819429a",
+        "version" : "0.36.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
-        "version" : "0.3.0"
+        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+        "version" : "0.5.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "680bf440178a78a627b1c2c64c0855f6523ad5b9",
-        "version" : "0.3.2"
+        "revision" : "2d6b7ffcc67afd9077fac5e5a29bcd6d39b71076",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Prose/ProseLib/Sources/App/AppReducer.swift
+++ b/Prose/ProseLib/Sources/App/AppReducer.swift
@@ -22,12 +22,12 @@ public let appReducer: Reducer<
 > = Reducer.combine([
     authenticationReducer.optional().pullback(
         state: \AppState.auth,
-        action: /AppAction.auth,
+        action: CasePath(AppAction.auth),
         environment: { $0.auth }
     ),
     mainWindowReducer.pullback(
         state: \AppState.main,
-        action: /AppAction.main,
+        action: CasePath(AppAction.main),
         environment: { $0.main }
     ).disabled(when: \.isMainWindowDisabled),
     Reducer { state, action, environment in
@@ -93,7 +93,7 @@ public let appReducer: Reducer<
                     //       see <https://github.com/prose-im/prose-app-macos/pull/37#discussion_r898929025>.
                 }
             }
-            
+
         case .main(.sidebar(.footer(.avatar(.signOutTapped)))):
             let jid = environment.userDefaults.loadCurrentAccount()
 

--- a/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationScreen.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/AuthenticationScreen.swift
@@ -26,8 +26,16 @@ public struct AuthenticationScreen: View {
 
     public var body: some View {
         SwitchStore(self.store.scope(state: \State.route)) {
-            CaseLet(state: /AuthRoute.basicAuth, action: Action.basicAuth, then: BasicAuthView.init(store:))
-            CaseLet(state: /AuthRoute.mfa, action: Action.mfa, then: MFAView.init(store:))
+            CaseLet(
+                state: CasePath(AuthRoute.basicAuth).extract(from:),
+                action: Action.basicAuth,
+                then: BasicAuthView.init(store:)
+            )
+            CaseLet(
+                state: CasePath(AuthRoute.mfa).extract(from:),
+                action: Action.mfa,
+                then: MFAView.init(store:)
+            )
         }
         .frame(minWidth: 400)
     }
@@ -43,13 +51,13 @@ public let authenticationReducer: Reducer<
     AuthenticationEnvironment
 > = Reducer.combine([
     basicAuthReducer._pullback(
-        state: (\AuthenticationState.route).case(/AuthRoute.basicAuth),
-        action: /AuthenticationAction.basicAuth,
+        state: (\AuthenticationState.route).case(CasePath(AuthRoute.basicAuth)),
+        action: CasePath(AuthenticationAction.basicAuth),
         environment: { $0 }
     ),
     mfaReducer._pullback(
-        state: (\AuthenticationState.route).case(/AuthRoute.mfa),
-        action: /AuthenticationAction.mfa,
+        state: (\AuthenticationState.route).case(CasePath(AuthRoute.mfa)),
+        action: CasePath(AuthenticationAction.mfa),
         environment: { $0 }
     ),
     Reducer { state, action, _ in

--- a/Prose/ProseLib/Sources/AuthenticationFeature/BasicAuthView.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/BasicAuthView.swift
@@ -89,7 +89,7 @@ struct BasicAuthView: View {
         .disabled(self.redactionReasons.contains(.placeholder))
         .popover(
             unwrapping: viewStore.binding(\.$popover),
-            case: /State.Popover.chatAddress,
+            case: CasePath(State.Popover.chatAddress),
             content: { _ in Self.chatAddressPopover() }
         )
     }
@@ -116,14 +116,14 @@ struct BasicAuthView: View {
             Button(l10n.PasswordLost.Action.title) { actions.send(.showPopoverTapped(.passwordLost)) }
                 .popover(
                     unwrapping: viewStore.binding(\.$popover),
-                    case: /State.Popover.passwordLost,
+                    case: CasePath(State.Popover.passwordLost),
                     content: { _ in Self.passwordLostPopover() }
                 )
             Divider().frame(height: 18)
             Button(l10n.NoAccount.Action.title) { actions.send(.showPopoverTapped(.noAccount)) }
                 .popover(
                     unwrapping: viewStore.binding(\.$popover),
-                    case: /State.Popover.noAccount,
+                    case: CasePath(State.Popover.noAccount),
                     content: { _ in Self.noAccountPopover() }
                 )
         }

--- a/Prose/ProseLib/Sources/AuthenticationFeature/MFA6DigitsView.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/MFA6DigitsView.swift
@@ -120,14 +120,14 @@ public struct MFA6DigitsView: View {
             Button(l10n.Footer.CannotGenerateCode.title) { actions.send(.showPopoverTapped(.cannotGenerateCode)) }
                 .popover(
                     unwrapping: viewStore.binding(\.$popover),
-                    case: /State.Popover.cannotGenerateCode,
+                    case: CasePath(State.Popover.cannotGenerateCode),
                     content: { _ in Self.cannotGenerateCodePopover() }
                 )
             Divider().frame(height: 18)
             Button(l10n.Footer.NoAccount.title) { actions.send(.showPopoverTapped(.noAccount)) }
                 .popover(
                     unwrapping: viewStore.binding(\.$popover),
-                    case: /State.Popover.noAccount,
+                    case: CasePath(State.Popover.noAccount),
                     content: { _ in BasicAuthView.noAccountPopover() }
                 )
         }

--- a/Prose/ProseLib/Sources/AuthenticationFeature/MFAView.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/MFAView.swift
@@ -19,7 +19,11 @@ struct MFAView: View {
 
     var body: some View {
         SwitchStore(self.store) {
-            CaseLet(state: /State.sixDigits, action: Action.sixDigits, then: MFA6DigitsView.init(store:))
+            CaseLet(
+                state: CasePath(State.sixDigits).extract(from:),
+                action: Action.sixDigits,
+                then: MFA6DigitsView.init(store:)
+            )
         }
     }
 }
@@ -34,8 +38,8 @@ public let mfaReducer: Reducer<
     AuthenticationEnvironment
 > = Reducer.combine([
     mfa6DigitsReducer.pullback(
-        state: /MFAState.sixDigits,
-        action: /MFAAction.sixDigits,
+        state: CasePath(MFAState.sixDigits),
+        action: CasePath(MFAAction.sixDigits),
         environment: { $0 }
     ),
     Reducer { _, action, _ in

--- a/Prose/ProseLib/Sources/ConversationFeature/ChatWithMessageBar.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/ChatWithMessageBar.swift
@@ -39,12 +39,12 @@ public let chatWithBarReducer: Reducer<
 > = Reducer.combine([
     chatReducer.pullback(
         state: \ChatWithBarState.chat,
-        action: /ChatWithBarAction.chat,
+        action: CasePath(ChatWithBarAction.chat),
         environment: { $0 }
     ),
     messageBarReducer.pullback(
         state: \ChatWithBarState.messageBar,
-        action: /ChatWithBarAction.messageBar,
+        action: CasePath(ChatWithBarAction.messageBar),
         environment: { _ in () }
     ),
 ])

--- a/Prose/ProseLib/Sources/ConversationFeature/ConversationScreen.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/ConversationScreen.swift
@@ -60,17 +60,17 @@ public let conversationReducer: Reducer<
 > = Reducer.combine([
     chatWithBarReducer.pullback(
         state: \ConversationState.chat,
-        action: /ConversationAction.chat,
+        action: CasePath(ConversationAction.chat),
         environment: { $0 }
     ),
     conversationInfoReducer.optional().pullback(
         state: \ConversationState.info,
-        action: /ConversationAction.info,
+        action: CasePath(ConversationAction.info),
         environment: { _ in () }
     ),
     toolbarReducer.pullback(
         state: \ConversationState.toolbar,
-        action: /ConversationAction.toolbar,
+        action: CasePath(ConversationAction.toolbar),
         environment: { _ in () }
     ),
     Reducer { state, action, environment in

--- a/Prose/ProseLib/Sources/ConversationInfoFeature/ConversationInfoView.swift
+++ b/Prose/ProseLib/Sources/ConversationInfoFeature/ConversationInfoView.swift
@@ -70,22 +70,22 @@ public let conversationInfoReducer: Reducer<
 > = Reducer.combine([
     identitySectionReducer.pullback(
         state: \ConversationInfoState.identity,
-        action: /ConversationInfoAction.identity,
+        action: CasePath(ConversationInfoAction.identity),
         environment: { $0 }
     ),
     quickActionsSectionReducer.pullback(
         state: \ConversationInfoState.quickActions,
-        action: /ConversationInfoAction.quickActions,
+        action: CasePath(ConversationInfoAction.quickActions),
         environment: { $0 }
     ),
     securitySectionReducer.pullback(
         state: \ConversationInfoState.security,
-        action: /ConversationInfoAction.security,
+        action: CasePath(ConversationInfoAction.security),
         environment: { $0 }
     ),
     actionsSectionReducer.pullback(
         state: \ConversationInfoState.actions,
-        action: /ConversationInfoAction.actions,
+        action: CasePath(ConversationInfoAction.actions),
         environment: { $0 }
     ),
 ])

--- a/Prose/ProseLib/Sources/MainWindowFeature/MainScreen.swift
+++ b/Prose/ProseLib/Sources/MainWindowFeature/MainScreen.swift
@@ -45,7 +45,7 @@ public let mainWindowReducer: Reducer<
     MainScreenEnvironment
 > = sidebarReducer._pullback(
     state: \MainScreenState.sidebar,
-    action: /MainScreenAction.sidebar,
+    action: CasePath(MainScreenAction.sidebar),
     environment: \MainScreenEnvironment.sidebar
 )
 

--- a/Prose/ProseLib/Sources/SidebarFeature/Footer/Footer.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Footer/Footer.swift
@@ -65,12 +65,12 @@ public let footerReducer: Reducer<
 > = Reducer.combine([
     footerActionMenuReducer.pullback(
         state: \.0.actionButton,
-        action: /FooterAction.actionButton,
+        action: CasePath(FooterAction.actionButton),
         environment: { $0 }
     ),
     footerAvatarReducer.pullback(
         state: \.0.avatar,
-        action: /FooterAction.avatar,
+        action: CasePath(FooterAction.avatar),
         environment: { $0 }
     ),
 ])

--- a/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterAvatar.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterAvatar.swift
@@ -214,7 +214,7 @@ public let footerAvatarReducer: Reducer<
 
     case let .changeAvailabilityTapped(availability):
         state.availability = availability
-        
+
     case .signOutTapped:
         state.showingPopover = false
 

--- a/Prose/ProseLib/Sources/SidebarFeature/NavigationDestinationView.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/NavigationDestinationView.swift
@@ -31,8 +31,15 @@ struct NavigationDestinationView: View {
 
     private func content() -> some View {
         SwitchStore(self.store) {
-            CaseLet(state: /State.chat, action: Action.chat, then: ConversationScreen.init(store:))
-            CaseLet(state: /State.unread, action: Action.unread) { store in
+            CaseLet(
+                state: CasePath(State.chat).extract(from:),
+                action: Action.chat,
+                then: ConversationScreen.init(store:)
+            )
+            CaseLet(
+                state: CasePath(State.unread).extract(from:),
+                action: Action.unread
+            ) { store in
                 UnreadScreen(store: store)
                     .groupBoxStyle(.spotlight)
             }
@@ -65,13 +72,13 @@ public let navigationDestinationReducer: Reducer<
     NavigationDestinationEnvironment
 > = Reducer.combine([
     unreadReducer.pullback(
-        state: /SidebarRoute.unread,
-        action: /NavigationDestinationAction.unread,
+        state: CasePath(SidebarRoute.unread),
+        action: CasePath(NavigationDestinationAction.unread),
         environment: { $0.unread }
     ),
     conversationReducer.pullback(
-        state: /SidebarRoute.chat,
-        action: /NavigationDestinationAction.chat,
+        state: CasePath(SidebarRoute.chat),
+        action: CasePath(NavigationDestinationAction.chat),
         environment: { $0.chat }
     ),
 ])

--- a/Prose/ProseLib/Sources/SidebarFeature/Sections/FavoritesSection.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Sections/FavoritesSection.swift
@@ -58,7 +58,7 @@ let favoritesSectionReducer: Reducer<
     SidebarEnvironment
 > = navigationDestinationReducer.optional().pullback(
     state: \FavoritesSectionState.route,
-    action: /FavoritesSectionAction.destination,
+    action: CasePath(FavoritesSectionAction.destination),
     environment: { $0.destination }
 )
 

--- a/Prose/ProseLib/Sources/SidebarFeature/Sections/GroupsSection.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Sections/GroupsSection.swift
@@ -68,7 +68,7 @@ let groupsSectionReducer: Reducer<
 > = Reducer.combine([
     navigationDestinationReducer.optional().pullback(
         state: \GroupsSectionState.route,
-        action: /GroupsSectionAction.destination,
+        action: CasePath(GroupsSectionAction.destination),
         environment: { $0.destination }
     ),
     Reducer { _, action, _ in

--- a/Prose/ProseLib/Sources/SidebarFeature/Sections/OtherContactsSection.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Sections/OtherContactsSection.swift
@@ -68,7 +68,7 @@ let otherContactsSectionReducer: Reducer<
 > = Reducer.combine([
     navigationDestinationReducer.optional().pullback(
         state: \OtherContactsSectionState.route,
-        action: /OtherContactsSectionAction.destination,
+        action: CasePath(OtherContactsSectionAction.destination),
         environment: { $0.destination }
     ),
     Reducer { _, action, _ in

--- a/Prose/ProseLib/Sources/SidebarFeature/Sections/SpotlightSection.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Sections/SpotlightSection.swift
@@ -62,7 +62,7 @@ let spotlightSectionReducer: Reducer<
     SidebarEnvironment
 > = navigationDestinationReducer.optional().pullback(
     state: \SpotlightSectionState.route,
-    action: /SpotlightSectionAction.destination,
+    action: CasePath(SpotlightSectionAction.destination),
     environment: { $0.destination }
 )
 

--- a/Prose/ProseLib/Sources/SidebarFeature/Sections/TeamMembersSection.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Sections/TeamMembersSection.swift
@@ -68,7 +68,7 @@ let teamMembersSectionReducer: Reducer<
 > = Reducer.combine([
     navigationDestinationReducer.optional().pullback(
         state: \TeamMembersSectionState.route,
-        action: /TeamMembersSectionAction.destination,
+        action: CasePath(TeamMembersSectionAction.destination),
         environment: { $0.destination }
     ),
     Reducer { _, action, _ in

--- a/Prose/ProseLib/Sources/SidebarFeature/SidebarContentView.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/SidebarContentView.swift
@@ -56,27 +56,27 @@ public let sidebarContentReducer: Reducer<
 > = Reducer.combine([
     spotlightSectionReducer.pullback(
         state: \SidebarContentState.spotlight,
-        action: /SidebarContentAction.spotlight,
+        action: CasePath(SidebarContentAction.spotlight),
         environment: { $0 }
     ),
     favoritesSectionReducer.pullback(
         state: \SidebarContentState.favorites,
-        action: /SidebarContentAction.favorites,
+        action: CasePath(SidebarContentAction.favorites),
         environment: { $0 }
     ),
     teamMembersSectionReducer.pullback(
         state: \SidebarContentState.teamMembers,
-        action: /SidebarContentAction.teamMembers,
+        action: CasePath(SidebarContentAction.teamMembers),
         environment: { $0 }
     ),
     otherContactsSectionReducer.pullback(
         state: \SidebarContentState.otherContacts,
-        action: /SidebarContentAction.otherContacts,
+        action: CasePath(SidebarContentAction.otherContacts),
         environment: { $0 }
     ),
     groupsSectionReducer.pullback(
         state: \SidebarContentState.groups,
-        action: /SidebarContentAction.groups,
+        action: CasePath(SidebarContentAction.groups),
         environment: { $0 }
     ),
     Reducer { state, action, _ in

--- a/Prose/ProseLib/Sources/SidebarFeature/SidebarView.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/SidebarView.swift
@@ -49,17 +49,17 @@ public let sidebarReducer: Reducer<
 > = Reducer.combine([
     sidebarContentReducer.pullback(
         state: \SidebarState.content,
-        action: /SidebarAction.content,
+        action: CasePath(SidebarAction.content),
         environment: { $0 }
     ),
     footerReducer.pullback(
         state: \SidebarState.footerView,
-        action: /SidebarAction.footer,
+        action: CasePath(SidebarAction.footer),
         environment: { _ in () }
     ),
     toolbarReducer.pullback(
         state: \SidebarState.toolbar,
-        action: /SidebarAction.toolbar,
+        action: CasePath(SidebarAction.toolbar),
         environment: { $0 }
     ),
 ])

--- a/Prose/ProseLib/Sources/TcaHelpers/OptionalPaths.swift
+++ b/Prose/ProseLib/Sources/TcaHelpers/OptionalPaths.swift
@@ -159,7 +159,7 @@ public extension OptionalPath where Root == Value {
 
 public extension OptionalPath where Root == Value? {
     static var some: OptionalPath {
-        .init(/Optional.some)
+        .init(CasePath(Optional.some))
     }
 }
 


### PR DESCRIPTION
`CasePath`s were interpreted as `Regex`es.
See https://github.com/pointfreeco/swift-case-paths/issues/81.