### PR TITLE
chore: Fix sidebar footer action menu design

### DIFF
--- a/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterActionMenu.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterActionMenu.swift
@@ -57,7 +57,7 @@ struct FooterActionMenu: View {
 
     fileprivate static func popover(store: Store<State, Action>) -> some View {
         let actions: ViewStore<Void, Action> = ViewStore(store.stateless)
-        return VStack(alignment: .leading) {
+        return VStack(alignment: .leading, spacing: 16) {
             // TODO: [Rémi Bardon] Refactor this view out
             HStack {
                 #if DEBUG
@@ -85,21 +85,13 @@ struct FooterActionMenu: View {
                 VStack(spacing: 4) {
                     Button { actions.send(.switchAccountTapped(account: "crisp.chat")) } label: {
                         Label {
-                            HStack(spacing: 4) {
-                                Text("Crisp")
-                                Text("–")
-                                Text("crisp.chat").monospacedDigit()
-                            }
+                            Text(verbatim: "Crisp – crisp.chat")
                             Spacer()
                             Image(systemName: "checkmark")
                                 .padding(.horizontal, 4)
                         } icon: {
                             // TODO: [Rémi Bardon] Change this to Crisp icon
-                            Image(PreviewAsset.Avatars.baptiste.name)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 24, height: 24)
-                                .cornerRadius(4)
+                            Avatar(.init(url: PreviewAsset.Avatars.baptiste.customURL), size: 24)
                         }
                         // Make hit box full width
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -109,18 +101,10 @@ struct FooterActionMenu: View {
                     .accessibilityLabel(L10n.Server.ConnectedTo.label("Crisp (crisp.chat)"))
                     Button { actions.send(.switchAccountTapped(account: "makair.life")) } label: {
                         Label {
-                            HStack(spacing: 4) {
-                                Text("MakAir")
-                                Text("–")
-                                Text("makair.life").monospacedDigit()
-                            }
+                            Text(verbatim: "MakAir – makair.life")
                         } icon: {
                             // TODO: [Rémi Bardon] Change this to MakAir icon
-                            Image(PreviewAsset.Avatars.baptiste.name)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 24, height: 24)
-                                .cornerRadius(4)
+                            Avatar(.init(url: PreviewAsset.Avatars.baptiste.customURL), size: 24)
                         }
                         // Make hit box full width
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -142,13 +126,16 @@ struct FooterActionMenu: View {
                 }
                 .buttonStyle(.plain)
             }
+            .groupBoxStyle(DefaultGroupBoxStyle())
 
             GroupBox(l10n.Server.ServerSettings.title) {
                 Link(destination: URL(string: "https://crisp.chat")!) {
                     HStack {
                         Text(l10n.Server.ServerSettings.Manage.label)
+                            .foregroundColor(.primary)
                         Spacer()
                         Image(systemName: "arrow.up.forward.square")
+                            .foregroundColor(.secondary)
                     }
                     // Make hit box full width
                     .frame(maxWidth: .infinity)
@@ -157,8 +144,13 @@ struct FooterActionMenu: View {
                 .foregroundColor(.accentColor)
             }
         }
-        .padding(8)
-        .frame(minWidth: 256)
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .buttonStyle(SidebarFooterPopoverButtonStyle())
+        .groupBoxStyle(VStackGroupBoxStyle(alignment: .leading, spacing: 6))
+        .multilineTextAlignment(.leading)
+        .padding(12)
+        .frame(width: 256)
     }
 }
 
@@ -223,18 +215,21 @@ public enum FooterActionMenuAction: Equatable, BindableAction {
 struct FooterActionMenu_Previews: PreviewProvider {
     private struct Preview: View {
         var body: some View {
-            FooterActionMenu(store: Store(
-                initialState: FooterActionMenuState(),
-                reducer: footerActionMenuReducer,
-                environment: ()
-            ))
-            .padding()
-            FooterActionMenu.popover(store: Store(
-                initialState: FooterActionMenuState(),
-                reducer: footerActionMenuReducer,
-                environment: ()
-            ))
-            .frame(width: 256)
+            VStack {
+                FooterActionMenu(store: Store(
+                    initialState: FooterActionMenuState(),
+                    reducer: footerActionMenuReducer,
+                    environment: ()
+                ))
+                Text("The popover 👇")
+                Text("(Previews can't display it)")
+                FooterActionMenu.popover(store: Store(
+                    initialState: FooterActionMenuState(),
+                    reducer: footerActionMenuReducer,
+                    environment: ()
+                ))
+                .border(Color.gray)
+            }
             .padding()
         }
     }

--- a/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterAvatar.swift
+++ b/Prose/ProseLib/Sources/SidebarFeature/Footer/FooterAvatar.swift
@@ -289,35 +289,45 @@ public enum FooterAvatarAction: Equatable, BindableAction {
             @Environment(\.redactionReasons) private var redactionReasons
 
             var body: some View {
-                HStack {
-                    ForEach(Availability.allCases, id: \.self) { availability in
-                        content(state: FooterAvatarState(
-                            avatar: .init(url: PreviewAsset.Avatars.valerian.customURL),
-                            availability: availability
-                        ))
+                VStack {
+                    HStack {
+                        ForEach(Availability.allCases, id: \.self) { availability in
+                            content(state: FooterAvatarState(
+                                avatar: .init(url: PreviewAsset.Avatars.valerian.customURL),
+                                availability: availability
+                            ))
+                        }
                     }
-                }
-                .padding()
-                let store = Store(
-                    initialState: FooterAvatarState(
-                        avatar: .init(url: PreviewAsset.Avatars.valerian.customURL),
-                        availability: .available
-                    ),
-                    reducer: footerAvatarReducer,
-                    environment: ()
-                )
-                FooterAvatar.popover(
-                    store: store,
-                    redactionReasons: redactionReasons
-                )
-                VStack(alignment: .leading) {
-                    FooterAvatar.availabilityMenu(
+                    .padding()
+                    let store = Store(
+                        initialState: FooterAvatarState(
+                            avatar: .init(url: PreviewAsset.Avatars.valerian.customURL),
+                            availability: .available
+                        ),
+                        reducer: footerAvatarReducer,
+                        environment: ()
+                    )
+                    Text("The popover 👇")
+                    Text("(Previews can't display it)")
+                    FooterAvatar.popover(
                         store: store,
                         redactionReasons: redactionReasons
                     )
+                    .border(Color.gray)
+                    Text("The availability menu 👇")
+                    Text("(Previews can't display it)")
+                    VStack(alignment: .leading) {
+                        FooterAvatar.availabilityMenu(
+                            store: store,
+                            redactionReasons: redactionReasons
+                        )
+                    }
+                    .padding()
+                    .frame(width: 256)
+                    .border(Color.gray)
+                    .buttonStyle(.plain)
                 }
                 .padding()
-                .buttonStyle(.plain)
             }
 
             private func content(state: FooterAvatarState) -> some View {


### PR DESCRIPTION
The sidebar footer action menu didn't follow the design artboards. I did better with the avatar button, but never took the time to fix the action menu. Here it is.

The artboards show:
<img width="464" alt="Screenshot 2022-06-22 at 13 51 22" src="https://user-images.githubusercontent.com/37386490/175022641-983861c4-2608-4b53-9b38-0e7a13ddb469.png">

The current implementation was:
<img width="1392" alt="Screenshot 2022-06-22 at 13 29 41" src="https://user-images.githubusercontent.com/37386490/175022732-c479863c-b3b4-4181-8855-6bc387367236.png">

and the avatar popover was:
<img width="1434" alt="Screenshot 2022-06-22 at 13 30 08" src="https://user-images.githubusercontent.com/37386490/175022773-be33e474-dac8-41d2-bfe4-e90acaa61719.png">

I reused the styles I had created to change the new popover to:
<img width="1392" alt="Screenshot 2022-06-22 at 13 50 43" src="https://user-images.githubusercontent.com/37386490/175022858-9027bc2b-cdb0-4dcc-8d95-afd5f2715276.png">

The "Switch account" picker cannot follow the spec, I tried hard but SwiftUI plays against me 😕 The new design is better I think.

I also fixed the account icons by the way.