### PR TITLE
Message reaction picker

### DIFF
--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/Chat.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/Chat.swift
@@ -342,31 +342,18 @@ struct ChatView: NSViewRepresentable {
         ))
       )
 
-      let show = {
-        picker.setFrameOrigin(pickerState.origin)
-
-        if picker.superview == nil {
-          webView.addSubview(picker)
-        }
-
-        assert(webView.window != nil)
-        if webView.window?.firstResponder != picker {
-          webView.window?.makeFirstResponder(picker)
-        }
-        DispatchQueue.main.async {
-          NSApp.orderFrontCharacterPalette(picker)
-        }
-      }
+      picker.setFrameOrigin(pickerState.origin)
 
       if picker.superview == nil {
-        DispatchQueue.main.async(execute: show)
-      } else {
-        logger.trace("Waiting a little for the previous character palette to close properly…")
-        // NOTE: [Rémi Bardon] If the character palette is already open, but we want to open
-        //       another one, macOS closes the first one, and doesn't show the new one because
-        //       one is already open at the time it tries to open it.
-        //       This magic number is the lowest delay I found, running on macOS 12.4.
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(600), execute: show)
+        webView.addSubview(picker)
+      }
+
+      assert(webView.window != nil)
+      if webView.window?.firstResponder != picker {
+        webView.window?.makeFirstResponder(picker)
+      }
+      DispatchQueue.main.async {
+        NSApp.orderFrontCharacterPalette(picker)
       }
     #else
       #warning("Show an emoji picker")

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/Chat.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/Chat.swift
@@ -71,6 +71,10 @@ struct Chat: View {
   }
 }
 
+public final class ChatWebView: WKWebView {
+  lazy var emojiPicker = EmojiPicker(origin: .zero)
+}
+
 struct ChatView: NSViewRepresentable {
   typealias State = ChatState
   typealias Action = ChatAction
@@ -103,7 +107,7 @@ struct ChatView: NSViewRepresentable {
 
   func makeCoordinator() -> Coordinator { Coordinator(viewStore: ViewStore(self.store.stateless)) }
 
-  func makeNSView(context: Context) -> WKWebView {
+  func makeNSView(context: Context) -> ChatWebView {
     let interval = signposter.beginInterval(#function, id: self.signpostID)
 
     let contentController = WKUserContentController()
@@ -131,7 +135,7 @@ struct ChatView: NSViewRepresentable {
     let configuration = WKWebViewConfiguration()
     configuration.userContentController = contentController
 
-    let webView = WKWebView(frame: .zero, configuration: configuration)
+    let webView = ChatWebView(frame: .zero, configuration: configuration)
     webView.loadFileURL(Files.messagingHtml.url, allowingReadAccessTo: Files.messagingHtml.url)
 
     signposter.endInterval(#function, interval)
@@ -192,7 +196,7 @@ struct ChatView: NSViewRepresentable {
     return webView
   }
 
-  func updateNSView(_ webView: WKWebView, context _: Context) {
+  func updateNSView(_ webView: ChatWebView, context _: Context) {
     let interval = signposter.beginInterval(#function, id: self.signpostID)
 
     if !webView.isLoading {

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
@@ -208,11 +208,6 @@ let chatReducer = Reducer<
     return .none
 
   case let .message(.showReactions(payload)):
-    guard state.emojiPicker == nil else {
-      logger.trace("Hiding reactions for \(String(describing: payload.ids)) (picker already open)…")
-      hideEmojiPicker()
-      return .none
-    }
     logger.trace("Showing reactions for \(String(describing: payload.ids))…")
 
     if let messageId: Message.ID = payload.ids.first {
@@ -257,7 +252,6 @@ let chatReducer = Reducer<
     guard let emoji = emoji,
           let messageId = state.targetedMessageId
     else { return .none }
-    hideEmojiPicker()
     return addReaction(emoji, on: messageId)
   }
 }

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
@@ -189,13 +189,15 @@ let chatReducer = Reducer<
 
     return Effect.future { completion in
       let picker = webView.emojiPicker
-      picker.frame.origin = origin
+      picker.setFrameOrigin(origin)
       picker.onSelection = { emoji in
         guard let emoji = emoji else { return }
         completion(.success(.addReaction(emoji, on: messageId)))
       }
 
-      webView.addSubview(picker)
+      if picker.superview == nil {
+        webView.addSubview(picker)
+      }
 
       assert(webView.window != nil)
       webView.window?.makeFirstResponder(picker)

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
@@ -75,7 +75,7 @@ extension JSEventError: CustomDebugStringConvertible {
 public enum ChatAction: Equatable {
   case webViewReady, alertDismissed
   case navigateUp, navigateDown
-  case showReactions(Message.ID, origin: CGPoint, webView: WKWebView)
+  case showReactions(Message.ID, origin: CGPoint, webView: ChatWebView)
   case addReaction(Character, on: Message.ID)
   case messageMenu(MessageMenuAction), menuDidClose
   case message(MessageAction)
@@ -135,11 +135,11 @@ let chatReducer = Reducer<
 
     let items: [MessageMenuItem]
     if let id: Message.ID = payload.ids.first {
-      #error("WKWebView() will be removed after rebasing")
+      #error("ChatWebView() will be removed after rebasing")
       items = [
         .item(.action(.copyText(id), title: "Copy text")),
         .item(.action(
-          .addReaction(id, origin: payload.origin.cgPoint, webView: WKWebView()),
+          .addReaction(id, origin: payload.origin.cgPoint, webView: ChatWebView()),
           title: "Add reaction…"
         )),
         .separator,
@@ -188,7 +188,8 @@ let chatReducer = Reducer<
     logger.trace("Reacting to \(String(describing: messageId))…")
 
     return Effect.future { completion in
-      let picker = EmojiPicker(origin: origin)
+      let picker = webView.emojiPicker
+      picker.frame.origin = origin
       picker.onSelection = { emoji in
         guard let emoji = emoji else { return }
         completion(.success(.addReaction(emoji, on: messageId)))
@@ -217,9 +218,9 @@ let chatReducer = Reducer<
     logger.trace("Showing reactions for \(String(describing: payload.ids))…")
 
     if let messageId: Message.ID = payload.ids.first {
-      #error("WKWebView() will be removed after rebasing")
+      #error("ChatWebView() will be removed after rebasing")
       return Effect(
-        value: .showReactions(messageId, origin: payload.origin.cgPoint, webView: WKWebView())
+        value: .showReactions(messageId, origin: payload.origin.cgPoint, webView: ChatWebView())
       )
     } else {
       logger.notice("Cannot show reactions: No message selected")

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
@@ -22,9 +22,11 @@ final class EmojiPicker: NSTextView {
 
     self.textContainerInset = NSSize.zero
     self.textContainer?.lineFragmentPadding = 0
-
-    self.backgroundColor = .systemRed
     self.font = .systemFont(ofSize: 1)
+
+//    #if DEBUG
+//    self.backgroundColor = .systemRed
+//    #endif
 
     self.delegate = self._delegate
   }

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
@@ -87,6 +87,8 @@ extension EmojiPickerView: NSTextInputClient {
     // This method is called when the user selects an emoji
     if let string = string as? String {
       self.viewStore.send(.didSelect(string.first))
+    } else {
+      fatalError("Emoji picker did not insert a String")
     }
   }
 

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
@@ -26,8 +26,13 @@ final class EmojiPicker: NSTextView {
 
     self.delegate = self._delegate
 
+    // Make insertion caret transparent
+    self.insertionPointColor = .clear
 //    #if DEBUG
 //    self.backgroundColor = .systemRed
+//    #else
+    // Remove the default white background
+    self.backgroundColor = .clear
 //    #endif
   }
 
@@ -45,6 +50,7 @@ final class EmojiPickerDelegate: NSObject, NSTextViewDelegate {
   func textDidChange(_ notification: Notification) {
     guard let textView = notification.object as? NSTextView else { return }
     self.onSelection?(textView.string.first)
+    textView.string = ""
     textView.removeFromSuperview()
   }
 }

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of prose-app-macos.
+// Copyright (c) 2022 Prose Foundation
+//
+
+import AppKit
+import WebKit
+
+final class EmojiPicker: NSTextView {
+  lazy var _delegate = EmojiPickerDelegate()
+
+  var onSelection: ((Character?) -> Void)? {
+    didSet { self._delegate.onSelection = self.onSelection }
+  }
+
+  override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+    super.init(frame: frameRect, textContainer: container)
+  }
+
+  init(origin: NSPoint) {
+    super.init(frame: NSRect(origin: origin, size: CGSize(width: 1, height: 1)))
+
+    self.textContainerInset = NSSize.zero
+    self.textContainer?.lineFragmentPadding = 0
+
+    self.backgroundColor = .systemRed
+    self.font = .systemFont(ofSize: 1)
+
+    self.delegate = self._delegate
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  deinit {
+    print("deinit")
+  }
+}
+
+final class EmojiPickerDelegate: NSObject, NSTextViewDelegate {
+  var onSelection: ((Character?) -> Void)?
+
+  func textDidChange(_ notification: Notification) {
+    guard let textView = notification.object as? NSTextView else { return }
+    self.onSelection?(textView.string.first)
+    textView.removeFromSuperview()
+  }
+}

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
@@ -4,53 +4,118 @@
 //
 
 import AppKit
+import ComposableArchitecture
+import ProseCoreTCA
 import WebKit
 
-final class EmojiPicker: NSTextView {
-  lazy var _delegate = EmojiPickerDelegate()
+public struct EmojiPickerState: Equatable {
+  let origin: CGPoint
+}
 
-  var onSelection: ((Character?) -> Void)? {
-    didSet { self._delegate.onSelection = self.onSelection }
-  }
+public enum EmojiPickerAction: Equatable {
+  case willAppear, willDisappear
+  case didSelect(Character?)
+}
 
-  override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
-    super.init(frame: frameRect, textContainer: container)
-  }
+final class EmojiPickerView: NSView {
+  var viewStore: ViewStore<EmojiPickerState, EmojiPickerAction>
 
-  init(origin: NSPoint) {
-    super.init(frame: NSRect(origin: origin, size: CGSize(width: 1, height: 1)))
+  init(viewStore: ViewStore<EmojiPickerState, EmojiPickerAction>) {
+    self.viewStore = viewStore
+    #if DEBUG
+      let size = CGSize(width: 1, height: 1)
+//      let size = CGSize(width: 10, height: 10)
+    #else
+      let size = CGSize(width: 1, height: 1)
+    #endif
+    super.init(frame: NSRect(origin: viewStore.state.origin, size: size))
 
-    self.textContainerInset = NSSize.zero
-    self.textContainer?.lineFragmentPadding = 0
-    self.font = .systemFont(ofSize: 1)
-
-    self.delegate = self._delegate
-
-    // Make insertion caret transparent
-    self.insertionPointColor = .clear
-//    #if DEBUG
-//    self.backgroundColor = .systemRed
-//    #else
-    // Remove the default white background
-    self.backgroundColor = .clear
-//    #endif
+    self.wantsLayer = true
+    assert(self.layer != nil)
+    self.layer?.backgroundColor = NSColor.systemRed.cgColor
   }
 
   @available(*, unavailable)
   required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-
-  override func accessibilityIsIgnored() -> Bool { true }
 }
 
-final class EmojiPickerDelegate: NSObject, NSTextViewDelegate {
-  var onSelection: ((Character?) -> Void)?
+extension EmojiPickerView {
+  override var acceptsFirstResponder: Bool { true }
 
-  func textDidChange(_ notification: Notification) {
-    guard let textView = notification.object as? NSTextView else { return }
-    self.onSelection?(textView.string.first)
-    textView.string = ""
-    textView.removeFromSuperview()
+  override func becomeFirstResponder() -> Bool {
+    #if DEBUG
+      assert(self.layer != nil)
+      self.layer?.backgroundColor = NSColor.systemGreen.cgColor
+    #endif
+
+    self.viewStore.send(.willAppear)
+
+    return super.becomeFirstResponder()
   }
+
+  @discardableResult override func resignFirstResponder() -> Bool {
+    #if DEBUG
+      assert(self.layer != nil)
+      self.layer?.backgroundColor = NSColor.systemGray.cgColor
+    #endif
+
+    // NOTE: This small delay is here because when clicking a button on screen
+    //       to show the emoji picker, the picker is first dismissed, because a click
+    //       was made outside, and then the button click event is received.
+    //       In order to handle the event properly (i.e. if we don't want to show the picker again),
+    //       we need to receive the dismiss event after the button click event.
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+      self.viewStore.send(.willDisappear)
+    }
+
+    return super.resignFirstResponder()
+  }
+
+  override func removeFromSuperview() {
+    #if DEBUG
+      assert(self.layer != nil)
+      self.layer?.backgroundColor = NSColor.systemPurple.cgColor
+    #endif
+    super.removeFromSuperview()
+  }
+}
+
+extension EmojiPickerView: NSTextInputClient {
+  func insertText(_ string: Any, replacementRange _: NSRange) {
+    // This method is called when the user selects an emoji
+    if let string = string as? String {
+      self.viewStore.send(.didSelect(string.first))
+    }
+  }
+
+  func setMarkedText(_: Any, selectedRange _: NSRange, replacementRange _: NSRange) {}
+
+  func unmarkText() {}
+
+  func selectedRange() -> NSRange { NSRange(location: 0, length: 0) }
+
+  func markedRange() -> NSRange { NSRange(location: NSNotFound, length: 0) }
+
+  func hasMarkedText() -> Bool { false }
+
+  func attributedSubstring(
+    forProposedRange _: NSRange,
+    actualRange _: NSRangePointer?
+  ) -> NSAttributedString? {
+    nil
+  }
+
+  func validAttributesForMarkedText() -> [NSAttributedString.Key] { [] }
+
+  func firstRect(forCharacterRange _: NSRange, actualRange _: NSRangePointer?) -> NSRect {
+    // The emoji picker uses the returned rect to position itself
+    var rect = self.bounds
+    rect.origin.x = rect.midX
+    rect.size.width = 0
+    return self.window!.convertToScreen(self.convert(rect, to: nil))
+  }
+
+  func characterIndex(for _: NSPoint) -> Int { 0 }
 }

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/EmojiPicker.swift
@@ -24,11 +24,11 @@ final class EmojiPicker: NSTextView {
     self.textContainer?.lineFragmentPadding = 0
     self.font = .systemFont(ofSize: 1)
 
+    self.delegate = self._delegate
+
 //    #if DEBUG
 //    self.backgroundColor = .systemRed
 //    #endif
-
-    self.delegate = self._delegate
   }
 
   @available(*, unavailable)
@@ -36,9 +36,7 @@ final class EmojiPicker: NSTextView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  deinit {
-    print("deinit")
-  }
+  override func accessibilityIsIgnored() -> Bool { true }
 }
 
 final class EmojiPickerDelegate: NSObject, NSTextViewDelegate {

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageMenu.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageMenu.swift
@@ -11,7 +11,7 @@ import WebKit
 public enum MessageMenuAction: Equatable {
   case copyText(Message.ID)
   case edit(Message.ID)
-  case addReaction(Message.ID, origin: CGPoint, webView: ChatWebView)
+  case addReaction(Message.ID, origin: CGPoint)
   case remove(Message.ID)
 }
 

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageMenu.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageMenu.swift
@@ -11,7 +11,7 @@ import WebKit
 public enum MessageMenuAction: Equatable {
   case copyText(Message.ID)
   case edit(Message.ID)
-  case addReaction(Message.ID, origin: CGPoint, webView: WKWebView)
+  case addReaction(Message.ID, origin: CGPoint, webView: ChatWebView)
   case remove(Message.ID)
 }
 

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageMenu.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/MessageMenu.swift
@@ -11,7 +11,7 @@ import WebKit
 public enum MessageMenuAction: Equatable {
   case copyText(Message.ID)
   case edit(Message.ID)
-  case addReaction(Message.ID)
+  case addReaction(Message.ID, origin: CGPoint, webView: WKWebView)
   case remove(Message.ID)
 }
 
@@ -165,6 +165,6 @@ public final class MessageMenu: NSMenu {
       return assertionFailure()
     }
 
-    viewStore.send(.messageMenuItemTapped(action))
+    viewStore.send(.messageMenu(action))
   }
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/37386490/182117014-409f8e19-5058-4a94-8245-d72f09f5d7ba.mov

I tried to make things clean, but the only approach I found was to use a tiny text field. I made sure we only create one and remove it whenever we can, so the web view doesn't have dozens of subviews.

Another thing: I started by developing the picker in SwiftUI, but when I tried to integrate it here, I couldn't put the focus on the `NSHostingView` for the popup to show in the right location.

It was easy to replicate it with AppKit, so I kept it that way. It's not something we will have to port to UIKit, so it's fine (I guess).