### PR TITLE
feat: Implement message bar emoji picker

### DIFF
--- a/Prose/ProseLib/Sources/ConversationFeature/MessageBar/MessageBar.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/MessageBar/MessageBar.swift
@@ -72,8 +72,11 @@ struct MessageBar: View {
       Button { actions.send(.addAttachmentTapped) } label: {
         Image(systemName: "paperclip")
       }
-      Button { actions.send(.showEmojisTapped) } label: {
-        Image(systemName: "face.smiling")
+      WithViewStore(self.store.scope(state: \.textField.isFocused)) { isFocused in
+        Button { actions.send(.showEmojisTapped) } label: {
+          Image(systemName: "face.smiling")
+        }
+        .disabled(!isFocused.state)
       }
     }
     .buttonStyle(.plain)
@@ -96,7 +99,18 @@ public let messageBarReducer: Reducer<
     action: CasePath(MessageBarAction.textField),
     environment: { $0 }
   ),
-  Reducer.empty.binding(),
+  Reducer { state, action, _ in
+    switch action {
+    case .showEmojisTapped:
+      if state.textField.isFocused {
+        NSApp.orderFrontCharacterPalette(nil)
+      }
+      return .none
+
+    default:
+      return .none
+    }
+  }.binding(),
 ])
 
 // MARK: State

--- a/Prose/ProseLib/Sources/ConversationFeature/MessageBar/MessageBarTextField.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/MessageBar/MessageBarTextField.swift
@@ -18,6 +18,8 @@ struct MessageBarTextField: View {
 
   @Environment(\.redactionReasons) private var redactionReasons
 
+  @FocusState private var isFocused: Bool
+
   let store: Store<State, Action>
   private var actions: ViewStore<Void, Action> { ViewStore(self.store.stateless) }
 
@@ -28,6 +30,7 @@ struct MessageBarTextField: View {
           l10n.fieldPlaceholder(viewStore.recipient),
           text: viewStore.binding(\State.$message)
         )
+        .focused(self.$isFocused)
         .padding(.vertical, 7.0)
         .padding(.leading, 16.0)
         .padding(.trailing, 4.0)
@@ -54,6 +57,7 @@ struct MessageBarTextField: View {
             .strokeBorder(Colors.Border.secondary.color)
         }
       )
+      .synchronize(viewStore.binding(\.$isFocused), self.$isFocused)
     }
   }
 }
@@ -83,6 +87,7 @@ public let messageBarTextFieldReducer: Reducer<
 public struct MessageBarTextFieldState: Equatable {
   var recipient: String
   @BindableState var message: String
+  @BindableState var isFocused: Bool = false
 
   public init(
     recipient: String,


### PR DESCRIPTION
As we don't have a reference to any `NSView`, I have to use `NSApp.orderFrontCharacterPalette(nil)`. If no text field is focused, the character palette will be useless, so I chose to disable the emoji button if the message bar text field is not focused:
<img width="1072" alt="Screenshot 2022-08-01 at 11 55 02" src="https://user-images.githubusercontent.com/37386490/182123328-82262d3f-df3e-44a8-ad55-1219ce9ada2d.png">
When it's focused, the button shows again:
<img width="1072" alt="Screenshot 2022-08-01 at 11 55 10" src="https://user-images.githubusercontent.com/37386490/182123342-44dbacc3-fb2d-4915-b8df-891a60ffd3da.png">
When tapped, the button shows the palette, at the correct location:
<img width="1075" alt="Screenshot 2022-08-01 at 11 55 44" src="https://user-images.githubusercontent.com/37386490/182123446-b4b260fa-7157-47fe-afd3-6551f6dfff84.png">
<img width="982" alt="Screenshot 2022-08-01 at 11 56 05" src="https://user-images.githubusercontent.com/37386490/182123511-09dd562c-8bee-49eb-ab0b-2e12ffe3d54a.png">

And finally, the button can be used multiple times without ending in a weird state.