### PR TITLE
Reactions & Retractions

### DIFF
--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "commander",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/Commander.git",
-      "state" : {
-        "revision" : "4a1f2fb82fb6cef613c4a25d2e38f702e4d812c2",
-        "version" : "0.9.2"
-      }
-    },
-    {
       "identity" : "kanna",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tid-kijyun/Kanna.git",
@@ -75,10 +66,10 @@
     {
       "identity" : "stencil",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/Stencil.git",
+      "location" : "https://github.com/stencilproject/Stencil.git",
       "state" : {
-        "revision" : "ccd9402682f4c07dac9561befd207c8156e80e20",
-        "version" : "0.14.2"
+        "revision" : "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
+        "version" : "0.15.1"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
       "state" : {
-        "revision" : "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
-        "version" : "2.8.0"
+        "revision" : "20e2de5322c83df005939d9d9300fab130b49f97",
+        "version" : "2.10.1"
       }
     },
     {
@@ -104,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "f8e35f6716c369c8412664052a0a7337da2ca0e3",
-        "version" : "0.49.9"
+        "revision" : "9a2fb9a9431e0ddea19dd6cb4395615129cf44cb",
+        "version" : "0.49.14"
       }
     },
     {
@@ -113,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftGen/SwiftGen",
       "state" : {
-        "revision" : "d498d285867f42ef0c74c5ebd9ddced747831372",
-        "version" : "6.5.1"
+        "revision" : "1db1ca768cdda4a2a1aef785f55167a1812fa9a0",
+        "version" : "6.6.1"
       }
     },
     {
@@ -131,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "f30119af03996939cc4f54e0bf0dda9f88a84da5",
-        "version" : "0.13.1"
+        "revision" : "ca932442d7481700f5434a7b138c47dd42d9902b",
+        "version" : "0.14.0"
       }
     },
     {

--- a/Prose/ConversationFeaturePreview/ContentView.swift
+++ b/Prose/ConversationFeaturePreview/ContentView.swift
@@ -74,7 +74,7 @@ struct ContentView: View {
       chatSubject.value[id: messageId]?.reactions.toggleReaction(reaction, for: jid)
       return Just(.none).setFailureType(to: EquatableError.self).eraseToEffect()
     }
-    client.retractMessage = { messageId in
+    client.retractMessage = { _, messageId in
       // TODO: Send an error if message is not found?
       chatSubject.value.remove(id: messageId)
       return Just(.none).setFailureType(to: EquatableError.self).eraseToEffect()

--- a/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/prose-im/prose-wrapper-swift",
       "state" : {
-        "branch" : "0.1.6",
-        "revision" : "a7700f3b34eab603e288b069c1af713dd34ee81a"
+        "branch" : "0.1.9",
+        "revision" : "2c90f5148d00808f41279d607da97e5eb8cef5e5"
       }
     },
     {

--- a/Prose/Prose.xcodeproj/xcshareddata/xcschemes/Prose.xcscheme
+++ b/Prose/Prose.xcodeproj/xcshareddata/xcschemes/Prose.xcscheme
@@ -88,7 +88,7 @@
          <EnvironmentVariable
             key = "PROSE_CORE_LOG_ENABLED"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
       .upToNextMajor(from: "0.1.0")
     ),
     .package(url: "https://github.com/pointfreeco/swift-tagged", .upToNextMajor(from: "0.7.0")),
-    .proseCore("0.1.6"),
+    .proseCore("0.1.9"),
   ],
   targets: [
     .target(

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
@@ -135,7 +135,6 @@ let chatReducer = Reducer<
 
     case let .remove(id):
       logger.trace("Retracting \(String(describing: id))…")
-      // NOTE: No need to `state.messages.removeAll(where:)` because the view will be automatically updated
       return environment.proseClient.retractMessage(state.chatId, id).fireAndForget()
     }
     return .none

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
@@ -192,11 +192,12 @@ let chatReducer = Reducer<
   case let .message(.toggleReaction(payload)):
     logger.trace("Toggling reaction \(payload.reaction) on \(String(describing: payload.ids))…")
 
-    guard let reaction = payload.reaction.first else { return .none }
-
     if let messageId = payload.ids.first {
-      return environment.proseClient.toggleReaction(state.chatId, messageId, reaction)
-        .fireAndForget()
+      return environment.proseClient.toggleReaction(
+        state.chatId,
+        messageId,
+        Reaction(payload.reaction)
+      ).fireAndForget()
     } else {
       logger.notice("Could not toggle reaction: No message selected")
       return .none

--- a/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/Chat/ChatReducer.swift
@@ -136,7 +136,7 @@ let chatReducer = Reducer<
     case let .remove(id):
       logger.trace("Retracting \(String(describing: id))…")
       // NOTE: No need to `state.messages.removeAll(where:)` because the view will be automatically updated
-      return environment.proseClient.retractMessage(id).fireAndForget()
+      return environment.proseClient.retractMessage(state.chatId, id).fireAndForget()
     }
     return .none
 

--- a/Prose/ProseLib/Sources/ProseCore/ProseClient.swift
+++ b/Prose/ProseLib/Sources/ProseCore/ProseClient.swift
@@ -13,10 +13,11 @@ enum ProseClientError: Error {
 public final class ProseClient: ProseClientProtocol {
   public private(set) weak var delegate: ProseClientDelegate?
 
-  private let client: ProseCoreClientFFI.Client
+  private let client: ProseCoreClientFFI.XmppClient
 
   /// When `true`, we're either already connected or in the midst of a connection attempt.
   private var isConnected = false
+  private var loadMessagesCompletionHandlers = [String: LoadMessagesCompletionHandler]()
 
   public var jid: BareJid {
     self.client.jid()
@@ -55,9 +56,9 @@ public final class ProseClient: ProseClientProtocol {
     id: String,
     to: BareJid,
     text: String,
-    chatState: ChatState?
+    chatState: XmppChatState?
   ) throws {
-    self.client.sendMessage(id: id, to: to, body: text, chatState: chatState)
+    try self.client.sendMessage(id: id, to: to, body: text, chatState: chatState)
   }
 
   public func updateMessage(
@@ -66,23 +67,71 @@ public final class ProseClient: ProseClientProtocol {
     to: BareJid,
     text: String
   ) throws {
-    self.client.updateMessage(id: id, newId: newID, to: to, body: text)
+    try self.client.updateMessage(id: id, newId: newID, to: to, body: text)
   }
 
-  public func sendChatState(to: BareJid, chatState: ChatState) throws {
-    self.client.sendChatState(to: to, chatState: chatState)
+  public func sendChatState(to: BareJid, chatState: XmppChatState) throws {
+    try self.client.sendChatState(to: to, chatState: chatState)
   }
 
-  public func sendPresence(show: ShowKind, status: String?) throws {
-    self.client.sendPresence(show: show, status: status)
+  public func sendPresence(show: XmppShowKind, status: String?) throws {
+    try self.client.sendPresence(show: show, status: status)
   }
 
   public func loadRoster() throws {
-    self.client.loadRoster()
+    try self.client.loadRoster()
+  }
+
+  public func loadMessagesInChat(
+    jid: BareJid,
+    before: MessageId?,
+    completion: @escaping LoadMessagesCompletionHandler
+  ) {
+    let requestId = UUID().uuidString
+    self.loadMessagesCompletionHandlers[requestId] = completion
+
+    do {
+      try self.client.loadMessagesInChat(requestId: requestId, jid: jid, before: before)
+    } catch {
+      self.loadMessagesCompletionHandlers[requestId] = nil
+      completion(.failure(error), false)
+    }
+  }
+
+  public func sendReactions(_ reactions: Set<String>, to: BareJid, messageId: MessageId) throws {
+    try self.client.sendReactions(id: messageId, to: to, reactions: Array(reactions))
+  }
+
+  public func retractMessage(to: BareJid, messageId: MessageId) throws {
+    try self.client.retractMessage(id: messageId, to: to)
+  }
+
+  public func addUserToRoster(jid: BareJid, nickname: String?, groups: Set<String>) throws {
+    try self.client.addUserToRoster(jid: jid, nickname: nickname, groups: Array(groups))
+  }
+
+  public func removeUserAndUnsubscribeFromPresence(jid: BareJid) throws {
+    try self.client.removeUserAndUnsubscribeFromPresence(jid: jid)
+  }
+
+  public func subscribeToUserPresence(jid: BareJid) throws {
+    try self.client.subscribeToUserPresence(jid: jid)
+  }
+
+  public func unsubscribeFromUserPresence(jid: BareJid) throws {
+    try self.client.unsubscribeFromUserPresence(jid: jid)
+  }
+
+  public func grantPresencePermissionToUser(jid: BareJid) throws {
+    try self.client.grantPresencePermissionToUser(jid: jid)
+  }
+
+  public func revokeOrRejectPresencePermissionFromUser(jid: BareJid) throws {
+    try self.client.revokeOrRejectPresencePermissionFromUser(jid: jid)
   }
 }
 
-extension ProseClient: AccountObserver {
+extension ProseClient: XmppAccountObserver {
   public func didConnect() {
     self.delegate?.proseClientDidConnect(self)
   }
@@ -94,15 +143,32 @@ extension ProseClient: AccountObserver {
     self.delegate?.proseClient(self, connectionDidFailWith: nil)
   }
 
-  public func didReceiveMessage(message: ProseCoreClientFFI.Message) {
+  public func didReceiveMessage(message: XmppMessage) {
     self.delegate?.proseClient(self, didReceiveMessage: message)
   }
 
-  public func didReceiveRoster(roster: ProseCoreClientFFI.Roster) {
+  public func didReceiveRoster(roster: XmppRoster) {
     self.delegate?.proseClient(self, didReceiveRoster: roster)
   }
 
-  public func didReceivePresence(presence: Presence) {
+  public func didReceivePresence(presence: XmppPresence) {
     self.delegate?.proseClient(self, didReceivePresence: presence)
+  }
+
+  public func didReceivePresenceSubscriptionRequest(from: BareJid) {
+    self.delegate?.proseClient(self, didReceivePresenceSubscriptionRequest: from)
+  }
+
+  public func didReceiveArchivingPreferences(preferences: XmppmamPreferences) {
+    self.delegate?.proseClient(self, didReceiveArchivingPreferences: preferences)
+  }
+
+  public func didReceiveMessagesInChat(
+    requestId: String,
+    jid _: BareJid,
+    messages: [XmppForwardedMessage],
+    isComplete: Bool
+  ) {
+    self.loadMessagesCompletionHandlers[requestId]?(.success(messages), isComplete)
   }
 }

--- a/Prose/ProseLib/Sources/ProseCore/ProseClientProtocol.swift
+++ b/Prose/ProseLib/Sources/ProseCore/ProseClientProtocol.swift
@@ -7,7 +7,7 @@ import Foundation
 import ProseCoreClientFFI
 
 public typealias ProseClientProvider<Client: ProseClientProtocol> =
-  (BareJid, ProseClientDelegate) -> Client
+  (BareJid, ProseClientDelegate, DispatchQueue) -> Client
 
 public typealias LoadMessagesCompletionHandler =
   (Result<[XmppForwardedMessage], Error>, _ isComplete: Bool) -> Void

--- a/Prose/ProseLib/Sources/ProseCore/ProseClientProtocol.swift
+++ b/Prose/ProseLib/Sources/ProseCore/ProseClientProtocol.swift
@@ -9,6 +9,9 @@ import ProseCoreClientFFI
 public typealias ProseClientProvider<Client: ProseClientProtocol> =
   (BareJid, ProseClientDelegate) -> Client
 
+public typealias LoadMessagesCompletionHandler =
+  (Result<[XmppForwardedMessage], Error>, _ isComplete: Bool) -> Void
+
 public protocol ProseClientProtocol: AnyObject {
   var jid: BareJid { get }
 
@@ -19,7 +22,7 @@ public protocol ProseClientProtocol: AnyObject {
     id: String,
     to: BareJid,
     text: String,
-    chatState: ChatState?
+    chatState: XmppChatState?
   ) throws
 
   func updateMessage(
@@ -29,10 +32,26 @@ public protocol ProseClientProtocol: AnyObject {
     text: String
   ) throws
 
-  func sendChatState(to: BareJid, chatState: ChatState) throws
-  func sendPresence(show: ShowKind, status: String?) throws
+  func retractMessage(to: BareJid, messageId: MessageId) throws
+
+  func loadMessagesInChat(
+    jid: BareJid,
+    before: MessageId?,
+    completion: @escaping LoadMessagesCompletionHandler
+  )
+
+  func sendChatState(to: BareJid, chatState: XmppChatState) throws
+  func sendPresence(show: XmppShowKind, status: String?) throws
+  func sendReactions(_ reactions: Set<String>, to: BareJid, messageId: MessageId) throws
 
   func loadRoster() throws
+
+  func addUserToRoster(jid: BareJid, nickname: String?, groups: Set<String>) throws
+  func removeUserAndUnsubscribeFromPresence(jid: BareJid) throws
+  func subscribeToUserPresence(jid: BareJid) throws
+  func unsubscribeFromUserPresence(jid: BareJid) throws
+  func grantPresencePermissionToUser(jid: BareJid) throws
+  func revokeOrRejectPresencePermissionFromUser(jid: BareJid) throws
 }
 
 public protocol ProseClientDelegate: AnyObject {
@@ -43,14 +62,22 @@ public protocol ProseClientDelegate: AnyObject {
   )
   func proseClient(
     _ client: ProseClientProtocol,
-    didReceiveRoster roster: ProseCoreClientFFI.Roster
+    didReceiveRoster roster: XmppRoster
   )
   func proseClient(
     _ client: ProseClientProtocol,
-    didReceiveMessage message: ProseCoreClientFFI.Message
+    didReceiveMessage message: XmppMessage
   )
   func proseClient(
     _ client: ProseClientProtocol,
-    didReceivePresence presence: Presence
+    didReceivePresence presence: XmppPresence
+  )
+  func proseClient(
+    _ client: ProseClientProtocol,
+    didReceivePresenceSubscriptionRequest from: BareJid
+  )
+  func proseClient(
+    _ client: ProseClientProtocol,
+    didReceiveArchivingPreferences preferences: XmppmamPreferences
   )
 }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
@@ -279,14 +279,14 @@ private final class Delegate: ProseClientDelegate, ObservableObject {
 
   func proseClient(
     _: ProseClientProtocol,
-    didReceiveRoster roster: ProseCoreClientFFI.Roster
+    didReceiveRoster roster: XmppRoster
   ) {
     self.roster = Roster(roster: roster)
   }
 
   func proseClient(
     _: ProseClientProtocol,
-    didReceiveMessage message: ProseCoreClientFFI.Message
+    didReceiveMessage message: XmppMessage
   ) {
     if message.replace == nil, let message = Message(message: message, timestamp: self.date()) {
       self.activeChats[message.from, default: Chat(jid: message.from)].appendMessage(message)
@@ -316,10 +316,23 @@ private final class Delegate: ProseClientDelegate, ObservableObject {
 
   func proseClient(
     _: ProseClientProtocol,
-    didReceivePresence presence: ProseCoreClientFFI.Presence
+    didReceivePresence presence: XmppPresence
   ) {
     if let jid = presence.from.map(JID.init) {
       self.presences[jid] = .init(presence: presence, timestamp: self.date())
     }
   }
+
+  func proseClient(
+    _ client: ProseClientProtocol,
+    didReceivePresenceSubscriptionRequest from: BareJid
+  ) {
+    try? client.grantPresencePermissionToUser(jid: from)
+    try? client.addUserToRoster(jid: from, nickname: nil, groups: [])
+  }
+
+  func proseClient(
+    _: ProseClientProtocol,
+    didReceiveArchivingPreferences _: XmppmamPreferences
+  ) {}
 }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
@@ -184,7 +184,7 @@ public extension ProseClient {
 
         return Just(.none).setFailureType(to: EquatableError.self).eraseToEffect()
       },
-      retractMessage: { _ in
+      retractMessage: { _, _ in
         fatalError("Not implemented yet.")
       },
       sendChatState: { to, kind in

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
@@ -57,7 +57,7 @@ public extension ProseClient {
     return ProseClient(
       login: { jid, password in
         delegate.account = .init(jid: jid, status: .connecting)
-        client = provider(jid.bareJid, delegate)
+        client = provider(jid.bareJid, delegate, .main)
 
         do {
           try client?.connect(credential: .password(password))

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Noop.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Noop.swift
@@ -32,7 +32,7 @@
       toggleReaction: { _, _, _ in
         Just(.none).setFailureType(to: EquatableError.self).eraseToEffect()
       },
-      retractMessage: { _ in
+      retractMessage: { _, _ in
         Just(.none).setFailureType(to: EquatableError.self).eraseToEffect()
       },
       sendChatState: { _, _ in

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
@@ -43,12 +43,13 @@ public struct ProseClient {
   public var addReaction: (
     _ to: JID,
     _ id: Message.ID,
-    _ reaction: Character
+    _ reaction: Reaction
   ) -> Effect<None, EquatableError>
+
   public var toggleReaction: (
     _ to: JID,
     _ id: Message.ID,
-    _ reaction: Character
+    _ reaction: Reaction
   ) -> Effect<None, EquatableError>
 
   public var retractMessage: (_ to: JID, _ id: Message.ID) -> Effect<None, EquatableError>

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
@@ -34,7 +34,11 @@ public struct ProseClient {
   /// messages and a second one where the new messages come in.
   public var messagesInChat: (_ with: JID) -> Effect<IdentifiedArrayOf<Message>, EquatableError>
 
+  /// Sends a message with the contents of `body` to the user with the specified JID.
   public var sendMessage: (_ to: JID, _ body: String) -> Effect<None, EquatableError>
+
+  /// Updates the message identified by `id` with the contents of `body` in a conversation
+  /// identified by `to`.
   public var updateMessage: (
     _ to: JID,
     _ id: Message.ID,
@@ -52,12 +56,19 @@ public struct ProseClient {
     _ reaction: Reaction
   ) -> Effect<None, EquatableError>
 
+  /// Retracts the message identified by `id` sent to a conversation identified by `to`.
   public var retractMessage: (_ to: JID, _ id: Message.ID) -> Effect<None, EquatableError>
+
+  /// Sends the user's current state `state` in a conversation identified by `to`.
   public var sendChatState: (_ to: JID, _ state: ChatState.Kind) -> Effect<None, EquatableError>
+
+  /// Sets the user's presence to `kind` with an optional status message `status`.
   public var sendPresence: (
     _ kind: Presence.Show,
     _ status: String?
   ) -> Effect<None, EquatableError>
 
+  /// Marks all messages read in a conversation identified by `jid` to
+  /// update `Chat.numberOfUnreadMessages` returned from the `activeChats` publisher.
   public var markMessagesReadInChat: (_ jid: JID) -> Effect<None, EquatableError>
 }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
@@ -50,8 +50,8 @@ public struct ProseClient {
     _ id: Message.ID,
     _ reaction: Character
   ) -> Effect<None, EquatableError>
-  public var retractMessage: (_ id: Message.ID) -> Effect<None, EquatableError>
 
+  public var retractMessage: (_ to: JID, _ id: Message.ID) -> Effect<None, EquatableError>
   public var sendChatState: (_ to: JID, _ state: ChatState.Kind) -> Effect<None, EquatableError>
   public var sendPresence: (
     _ kind: Presence.Show,

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Chat.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Chat.swift
@@ -46,6 +46,12 @@ extension Chat {
     }
   }
 
+  mutating func removeMessage(id: Message.ID) {
+    if self.messages.remove(id: id)?.isRead == false {
+      self.numberOfUnreadMessages -= 1
+    }
+  }
+
   mutating func markMessagesRead() {
     self.messages.ids.forEach { id in
       self.messages[id: id]?.isRead = true

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Chat.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Chat.swift
@@ -57,6 +57,23 @@ extension Chat {
     self.messages.ids.contains(id)
   }
 
+  /// Replaces the message identified by `id` with `message` if a message with `id` exists. Use
+  /// this method instead of ``updateMessage(id:with:)`` if the identity of `message` is different
+  /// from the one being replaced.
+  ///
+  /// - Parameters:
+  ///   - id: The id of the message to replace.
+  ///   - message: The replacement for the message.
+  /// - Returns: `true` if a message with `id` existed and was replaced, `false` otherwise.
+  @discardableResult mutating func replaceMessage(id: Message.ID, with message: Message) -> Bool {
+    guard let idx = self.messages.index(id: id) else {
+      return false
+    }
+    self.messages.remove(at: idx)
+    self.messages.insert(message, at: idx)
+    return true
+  }
+
   @discardableResult
   mutating func updateMessage(id: Message.ID, with handler: (inout Message) -> Void) -> Bool {
     guard self.messages.ids.contains(id) else {

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Chat.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Chat.swift
@@ -74,12 +74,22 @@ extension Chat {
     return true
   }
 
-  @discardableResult
-  mutating func updateMessage(id: Message.ID, with handler: (inout Message) -> Void) -> Bool {
-    guard self.messages.ids.contains(id) else {
+  /// Transforms message identified by `id` using `handler` in a transactional manner. If `handler`
+  /// throws, the message will not be updated.
+  ///
+  /// - Parameters:
+  ///   - id: The id of the message to update.
+  ///   - handler: The handler used to transform the message.
+  /// - Returns: `true` if message with id exists, `false` otherwise.
+  @discardableResult mutating func updateMessage(
+    id: Message.ID,
+    with handler: (inout Message) throws -> Void
+  ) rethrows -> Bool {
+    guard var message = self.messages[id: id] else {
       return false
     }
-    handler(&self.messages[id: id]!)
+    try handler(&message)
+    self.messages[id: id] = message
     return true
   }
 }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/ChatState.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/ChatState.swift
@@ -28,7 +28,7 @@ public extension ChatState {
 }
 
 extension ChatState {
-  init(state: ProseCoreClientFFI.ChatState, timestamp: Date) {
+  init(state: XmppChatState, timestamp: Date) {
     switch state {
     case .active:
       self.kind = .active
@@ -48,7 +48,7 @@ extension ChatState {
 }
 
 extension ChatState.Kind {
-  var ffi: ProseCoreClientFFI.ChatState {
+  var ffi: XmppChatState {
     switch self {
     case .active:
       return .active

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -41,7 +41,7 @@ public struct Message: Equatable, Identifiable {
 }
 
 extension Message {
-  init?(message: ProseCoreClientFFI.Message, timestamp: Date) {
+  init?(message: XmppMessage, timestamp: Date) {
     // We'll discard messages with empty bodies and messages without ids. Ids don't seem to be
     // specified in the XMPP spec but our current server adds them, unless you send a message to
     // yourself.
@@ -70,7 +70,7 @@ public enum MessageKind: Equatable {
 }
 
 extension MessageKind {
-  init(kind: ProseCoreClientFFI.MessageKind) {
+  init(kind: XmppMessageKind) {
     switch kind {
     case .chat:
       self = .chat

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -123,10 +123,8 @@ struct StringCodingKey: CodingKey {
 
   var intValue: Int?
 
-  init(intValue: Int) {
-    self.init(stringValue: String(describing: intValue))
-    // We never want integer keys
-//    self.intValue = intValue
+  init?(intValue _: Int) {
+    nil
   }
 }
 

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -45,7 +45,11 @@ extension Message {
     // We'll discard messages with empty bodies and messages without ids. Ids don't seem to be
     // specified in the XMPP spec but our current server adds them, unless you send a message to
     // yourself.
-    guard let body = message.body, let id = message.id else {
+    guard
+      let body = message.body,
+      let id = message.id,
+      message.fastening == nil
+    else {
       return nil
     }
 

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -89,27 +89,27 @@ extension MessageKind {
 }
 
 public struct MessageReactions: Equatable {
-  var reactions: [Character: Set<JID>]
+  var reactions: [Reaction: Set<JID>]
 
-  public init(reactions: [Character: Set<JID>] = [:]) {
+  public init(reactions: [Reaction: Set<JID>] = [:]) {
     self.reactions = reactions
   }
 
-  public mutating func addReaction(_ reaction: Character, for jid: JID) {
+  public mutating func addReaction(_ reaction: Reaction, for jid: JID) {
     self.reactions[reaction, default: Set<JID>()].insert(jid)
   }
 
-  public mutating func toggleReaction(_ reaction: Character, for jid: JID) {
+  public mutating func toggleReaction(_ reaction: Reaction, for jid: JID) {
     self.reactions.prose_toggle(jid, forKey: reaction)
   }
-  
+
   subscript(reaction: Reaction) -> Set<JID>? {
     self.reactions[reaction]
   }
 }
 
 extension MessageReactions: ExpressibleByDictionaryLiteral {
-  public init(dictionaryLiteral elements: (Character, Set<JID>)...) {
+  public init(dictionaryLiteral elements: (Reaction, Set<JID>)...) {
     self.init(reactions: Dictionary(uniqueKeysWithValues: elements))
   }
 }
@@ -119,10 +119,6 @@ struct StringCodingKey: CodingKey {
 
   init(stringValue: String) {
     self.stringValue = stringValue
-  }
-
-  init(_ character: Character) {
-    self.init(stringValue: String(describing: character))
   }
 
   var intValue: Int?
@@ -140,7 +136,7 @@ extension MessageReactions: Encodable {
 
     for (key, value) in self.reactions {
       let jids: [String] = value.map(\.jidString)
-      try container.encode(jids, forKey: StringCodingKey(key))
+      try container.encode(jids, forKey: StringCodingKey(stringValue: key.rawValue))
     }
   }
 }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -102,6 +102,10 @@ public struct MessageReactions: Equatable {
   public mutating func toggleReaction(_ reaction: Character, for jid: JID) {
     self.reactions.prose_toggle(jid, forKey: reaction)
   }
+  
+  subscript(reaction: Reaction) -> Set<JID>? {
+    self.reactions[reaction]
+  }
 }
 
 extension MessageReactions: ExpressibleByDictionaryLiteral {

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -103,6 +103,24 @@ public struct MessageReactions: Equatable {
     self.reactions.prose_toggle(jid, forKey: reaction)
   }
 
+  public mutating func setReactions(_ reactions: [Reaction], for jid: JID) {
+    for (reaction, _) in self.reactions {
+      self.reactions[reaction]?.remove(jid)
+      if self.reactions[reaction]?.isEmpty == true {
+        self.reactions.removeValue(forKey: reaction)
+      }
+    }
+    for reaction in reactions {
+      self.reactions[reaction, default: []].insert(jid)
+    }
+  }
+
+  func reactions(for jid: JID) -> [Reaction] {
+    self.reactions.compactMap { reaction, jids in
+      jids.contains(jid) ? reaction : nil
+    }
+  }
+
   subscript(reaction: Reaction) -> Set<JID>? {
     self.reactions[reaction]
   }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Presence.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Presence.swift
@@ -42,7 +42,7 @@ public extension Presence {
 }
 
 extension Presence {
-  init(presence: ProseCoreClientFFI.Presence, timestamp: Date) {
+  init(presence: XmppPresence, timestamp: Date) {
     self.kind = presence.kind.map(Presence.Kind.init)
     self.show = presence.show.map(Presence.Show.init)
     self.status = presence.status
@@ -51,7 +51,7 @@ extension Presence {
 }
 
 extension Presence.Kind {
-  init(kind: PresenceKind) {
+  init(kind: XmppPresenceKind) {
     switch kind {
     case .unavailable:
       self = .unavailable
@@ -74,7 +74,7 @@ extension Presence.Kind {
 }
 
 extension Presence.Show {
-  init(show: ShowKind) {
+  init(show: XmppShowKind) {
     switch show {
     case .away:
       self = .away
@@ -91,7 +91,7 @@ extension Presence.Show {
 }
 
 extension Presence.Show {
-  var ffi: ProseCoreClientFFI.ShowKind {
+  var ffi: XmppShowKind {
     switch self {
     case .away:
       return .away

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Reaction.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Reaction.swift
@@ -1,0 +1,37 @@
+//
+// This file is part of prose-app-macos.
+// Copyright (c) 2022 Prose Foundation
+//
+
+import Foundation
+
+public struct Reaction:
+  Codable,
+  Hashable,
+  RawRepresentable,
+  CustomStringConvertible,
+  ExpressibleByStringLiteral,
+  CustomDebugStringConvertible
+{
+  public var rawValue: String
+
+  public init(_ value: String) {
+    self.rawValue = value
+  }
+
+  public init(stringLiteral value: String) {
+    self.rawValue = value
+  }
+
+  public init(rawValue value: String) {
+    self.rawValue = value
+  }
+
+  public var debugDescription: String {
+    self.rawValue
+  }
+
+  public var description: String {
+    self.rawValue
+  }
+}

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Roster.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Roster.swift
@@ -48,13 +48,13 @@ public extension Roster.Group.Item {
 }
 
 extension Roster {
-  init(roster: ProseCoreClientFFI.Roster) {
+  init(roster: XmppRoster) {
     self.init(groups: roster.groups.map(Group.init))
   }
 }
 
 extension Roster.Group {
-  init(group: ProseCoreClientFFI.RosterGroup) {
+  init(group: XmppRosterGroup) {
     self.init(
       name: group.name,
       items: group.items.map(Item.init)
@@ -63,7 +63,7 @@ extension Roster.Group {
 }
 
 extension Roster.Group.Item {
-  init(item: ProseCoreClientFFI.RosterItem) {
+  init(item: XmppRosterItem) {
     self.init(
       jid: .init(bareJid: item.jid),
       subscription: .init(subscription: item.subscription)
@@ -72,7 +72,7 @@ extension Roster.Group.Item {
 }
 
 extension Roster.Group.Item.Subscription {
-  init(subscription: ProseCoreClientFFI.RosterItemSubscription) {
+  init(subscription: XmppRosterItemSubscription) {
     switch subscription {
     case .none:
       self = .none

--- a/Prose/ProseLib/Sources/ProseUI/View+OnKeyDown.swift
+++ b/Prose/ProseLib/Sources/ProseUI/View+OnKeyDown.swift
@@ -63,7 +63,7 @@ public extension View {
   ///         we ensure ``KeyAwareView`` stays first responder as long as we need it to, and it correctly
   ///         receives the key events.
   func onKeyDown(perform onEvent: @escaping (KeyEvent) -> Void) -> some View {
-    KeyAwareView(rootView: self, onEvent: onEvent)
+    KeyAwareView(rootView: self, onEvent: onEvent).accessibilityElement(children: .contain)
   }
 
   func onKeyDown(_ key: KeyEvent, perform onEvent: @escaping () -> Void) -> some View {

--- a/Prose/ProseLib/Sources/TestHostApp/Mocks/AppEnvironment.swift
+++ b/Prose/ProseLib/Sources/TestHostApp/Mocks/AppEnvironment.swift
@@ -12,6 +12,7 @@ extension AppEnvironment {
     userDefaults: .placeholder,
     credentials: .placeholder,
     proseClient: .noop,
+    pasteboard: .noop,
     notifications: .noop,
     mainQueue: .main,
     openURL: { url, _ in

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/Message+Mock.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/Message+Mock.swift
@@ -7,15 +7,17 @@ import Foundation
 import ProseCoreClientFFI
 import ProseCoreTCA
 
-extension ProseCoreClientFFI.Message {
+extension XmppMessage {
   static func mock(
     from: BareJid = "jane.doe@prose.org",
     to: BareJid? = nil,
     id: String? = "message-id",
-    kind: ProseCoreClientFFI.MessageKind? = nil,
+    kind: XmppMessageKind? = nil,
     body: String? = "Empty Message",
-    chatState: ProseCoreClientFFI.ChatState? = nil,
+    chatState: XmppChatState? = nil,
     replace: String? = nil,
+    reactions: XmppMessageReactions? = nil,
+    fastening: XmppMessageFastening? = nil,
     error: String? = nil
   ) -> Self {
     .init(
@@ -26,6 +28,8 @@ extension ProseCoreClientFFI.Message {
       body: body,
       chatState: chatState,
       replace: replace,
+      reactions: reactions,
+      fastening: fastening,
       error: error
     )
   }

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/Presence+Mock.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/Presence+Mock.swift
@@ -7,12 +7,12 @@ import Foundation
 import ProseCoreClientFFI
 import ProseCoreTCA
 
-extension ProseCoreClientFFI.Presence {
+extension XmppPresence {
   static func mock(
-    kind: PresenceKind? = nil,
+    kind: XmppPresenceKind? = nil,
     from: BareJid? = "jane.doe@prose.org",
     to: BareJid? = nil,
-    show: ShowKind? = nil,
+    show: XmppShowKind? = nil,
     status: String? = nil
   ) -> Self {
     .init(

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/ProseMockClient.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/ProseMockClient.swift
@@ -26,7 +26,7 @@ final class ProseMockClient: ProseClientProtocol {
     self.impl.disconnect()
   }
 
-  func sendMessage(id: String, to: BareJid, text: String, chatState: ChatState?) throws {
+  func sendMessage(id: String, to: BareJid, text: String, chatState: XmppChatState?) throws {
     try self.impl.sendMessage(id, to, text, chatState)
   }
 
@@ -34,16 +34,56 @@ final class ProseMockClient: ProseClientProtocol {
     try self.impl.updateMessage(id, newID, to, text)
   }
 
-  func sendChatState(to: BareJid, chatState: ChatState) throws {
+  func sendChatState(to: BareJid, chatState: XmppChatState) throws {
     try self.impl.sendChatState(to, chatState)
   }
 
-  func sendPresence(show: ShowKind, status: String?) throws {
+  func sendPresence(show: XmppShowKind, status: String?) throws {
     try self.impl.sendPresence(show, status)
   }
 
   func loadRoster() throws {
     try self.impl.loadRoster()
+  }
+
+  func retractMessage(to: BareJid, messageId: MessageId) throws {
+    try self.impl.retractMessage(to, messageId)
+  }
+
+  func loadMessagesInChat(
+    jid: BareJid,
+    before: MessageId?,
+    completion: @escaping LoadMessagesCompletionHandler
+  ) {
+    self.impl.loadMessagesInChat(jid, before, completion)
+  }
+
+  func sendReactions(_ reactions: Set<String>, to: BareJid, messageId: MessageId) throws {
+    try self.impl.sendReactions(reactions, to, messageId)
+  }
+
+  func addUserToRoster(jid: BareJid, nickname: String?, groups: Set<String>) throws {
+    try self.impl.addUserToRoster(jid, nickname, groups)
+  }
+
+  func removeUserAndUnsubscribeFromPresence(jid: BareJid) throws {
+    try self.impl.removeUserAndUnsubscribeFromPresence(jid)
+  }
+
+  func subscribeToUserPresence(jid: BareJid) throws {
+    try self.impl.subscribeToUserPresence(jid)
+  }
+
+  func unsubscribeFromUserPresence(jid: BareJid) throws {
+    try self.impl.unsubscribeFromUserPresence(jid)
+  }
+
+  func grantPresencePermissionToUser(jid: BareJid) throws {
+    try self.impl.grantPresencePermissionToUser(jid)
+  }
+
+  func revokeOrRejectPresencePermissionFromUser(jid: BareJid) throws {
+    try self.impl.revokeOrRejectPresencePermissionFromUser(jid)
   }
 }
 
@@ -51,7 +91,7 @@ extension ProseMockClient {
   static func provider(
     _ handler: @escaping (ProseMockClient) -> Void
   ) -> ProseClientProvider<ProseMockClient> {
-    { jid, delegate in
+    { jid, delegate, _ in
       let client = ProseMockClient(jid: jid, delegate: delegate)
       handler(client)
       return client
@@ -62,9 +102,21 @@ extension ProseMockClient {
 struct ProseMockClientImpl {
   var connect: (ProseCore.Credential) throws -> Void = { _ in }
   var disconnect: () -> Void = {}
-  var sendMessage: (String, BareJid, String, ChatState?) throws -> Void = { _, _, _, _ in }
+  var sendMessage: (String, BareJid, String, XmppChatState?) throws -> Void = { _, _, _, _ in }
   var updateMessage: (String, String, BareJid, String) throws -> Void = { _, _, _, _ in }
-  var sendChatState: (BareJid, ChatState) throws -> Void = { _, _ in }
-  var sendPresence: (ShowKind, String?) throws -> Void = { _, _ in }
+  var sendChatState: (BareJid, XmppChatState) throws -> Void = { _, _ in }
+  var sendPresence: (XmppShowKind, String?) throws -> Void = { _, _ in }
   var loadRoster: () throws -> Void = {}
+  var retractMessage: (BareJid, MessageId) throws -> Void = { _, _ in }
+  var loadMessagesInChat: (BareJid, MessageId?, LoadMessagesCompletionHandler)
+    -> Void = { _, _, _ in
+    }
+
+  var sendReactions: (Set<String>, BareJid, MessageId) throws -> Void = { _, _, _ in }
+  var addUserToRoster: (BareJid, String?, Set<String>) throws -> Void = { _, _, _ in }
+  var removeUserAndUnsubscribeFromPresence: (BareJid) throws -> Void = { _ in }
+  var subscribeToUserPresence: (BareJid) throws -> Void = { _ in }
+  var unsubscribeFromUserPresence: (BareJid) throws -> Void = { _ in }
+  var grantPresencePermissionToUser: (BareJid) throws -> Void = { _ in }
+  var revokeOrRejectPresencePermissionFromUser: (BareJid) throws -> Void = { _ in }
 }

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/MessageReactionsTests.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/MessageReactionsTests.swift
@@ -1,0 +1,73 @@
+//
+// This file is part of prose-app-macos.
+// Copyright (c) 2022 Prose Foundation
+//
+
+import Foundation
+@testable import ProseCoreTCA
+import XCTest
+
+final class MessageReactionsTests: XCTestCase {
+  func testAddReaction() {
+    var reactions = MessageReactions()
+    reactions.addReaction("❤️", for: "1")
+    reactions.addReaction("❤️", for: "1")
+    reactions.addReaction("🤷‍♂️", for: "1")
+    reactions.addReaction("🤷‍♂️", for: "2")
+    reactions.addReaction("🫠", for: "2")
+
+    XCTAssertEqual(reactions, ["❤️": ["1"], "🤷‍♂️": ["1", "2"], "🫠": ["2"]])
+  }
+
+  func testToggleReaction() {
+    var reactions = MessageReactions()
+    reactions.toggleReaction("❤️", for: "1")
+    reactions.toggleReaction("❤️", for: "2")
+    XCTAssertEqual(reactions, ["❤️": ["1", "2"]])
+
+    reactions.toggleReaction("❤️", for: "1")
+    XCTAssertEqual(reactions, ["❤️": ["2"]])
+
+    reactions.toggleReaction("❤️", for: "2")
+    XCTAssertEqual(reactions, [:])
+  }
+
+  func testSetReactions() {
+    var reactions: MessageReactions = [
+      "❤️": ["1", "2"],
+      "🤷‍♂️": ["1"],
+      "🫠": ["2"],
+    ]
+
+    reactions.setReactions(["🫠", "🐇"], for: "1")
+    XCTAssertEqual(
+      reactions,
+      [
+        "❤️": ["2"],
+        "🫠": ["1", "2"],
+        "🐇": ["1"],
+      ]
+    )
+
+    reactions.setReactions([], for: "1")
+    XCTAssertEqual(
+      reactions,
+      [
+        "❤️": ["2"],
+        "🫠": ["2"],
+      ]
+    )
+
+    reactions.setReactions([], for: "2")
+    XCTAssertEqual(reactions, [:])
+  }
+
+  func testReactionsForJID() {
+    let reactions: MessageReactions = [
+      "❤️": ["1", "2"],
+      "🤷‍♂️": ["1"],
+      "🫠": ["2"],
+    ]
+    XCTAssertEqual(Set(reactions.reactions(for: "2")), ["❤️", "🫠"])
+  }
+}

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/ProseClientTests.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/ProseClientTests.swift
@@ -9,14 +9,15 @@ import ProseCore
 import ProseCoreTCA
 import TestHelpers
 import XCTest
+import IdentifiedCollections
 
 final class ProseClientTests: XCTestCase {
   func testGroupsMessagesInChatsWhenReceiving() throws {
     let date = Date.ymd(2022, 6, 25)
     let (client, mock) = try self.connectedClient(date: { date })
 
-    let chat1Messages = TestSink<[Message]>()
-    let chat2Messages = TestSink<[Message]>()
+    let chat1Messages = TestSink<IdentifiedArrayOf<Message>>()
+    let chat2Messages = TestSink<IdentifiedArrayOf<Message>>()
     var c = Set<AnyCancellable>()
 
     client.messagesInChat("chat1@prose.org").collectInto(sink: chat1Messages).store(in: &c)
@@ -48,8 +49,8 @@ final class ProseClientTests: XCTestCase {
     let date = Date.ymd(2022, 6, 25)
     let (client, _) = try self.connectedClient(date: { date })
 
-    let chat1Messages = TestSink<[Message]>()
-    let chat2Messages = TestSink<[Message]>()
+    let chat1Messages = TestSink<IdentifiedArrayOf<Message>>()
+    let chat2Messages = TestSink<IdentifiedArrayOf<Message>>()
     var c = Set<AnyCancellable>()
 
     client.messagesInChat("chat1@prose.org").collectInto(sink: chat1Messages).store(in: &c)
@@ -194,7 +195,7 @@ final class ProseClientTests: XCTestCase {
     let date = Date.ymd(2022, 6, 25)
     let (client, _) = try self.connectedClient(date: { date })
 
-    let chat1Messages = TestSink<[Message]>()
+    let chat1Messages = TestSink<IdentifiedArrayOf<Message>>()
     var c = Set<AnyCancellable>()
 
     try self.await(client.sendMessage("chat1@prose.org", "message 1"))
@@ -257,7 +258,7 @@ final class ProseClientTests: XCTestCase {
     let date = Date.ymd(2022, 6, 25)
     let (client, mock) = try self.connectedClient(date: { date })
 
-    let chat1Messages = TestSink<[Message]>()
+    let chat1Messages = TestSink<IdentifiedArrayOf<Message>>()
     var c = Set<AnyCancellable>()
 
     mock.delegate.proseClient(mock, didReceiveMessage: .mock(from: "chat1@prose.org", id: "1"))

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/ProseClientTests.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/ProseClientTests.swift
@@ -5,11 +5,11 @@
 
 import Combine
 import Foundation
+import IdentifiedCollections
 import ProseCore
 import ProseCoreTCA
 import TestHelpers
 import XCTest
-import IdentifiedCollections
 
 final class ProseClientTests: XCTestCase {
   func testGroupsMessagesInChatsWhenReceiving() throws {

--- a/Prose/ProseUITests/RosterSelectionTests.swift
+++ b/Prose/ProseUITests/RosterSelectionTests.swift
@@ -7,6 +7,10 @@ import Foundation
 import XCTest
 
 final class RosterSelectionTests: XCTestCase {
+  override func setUp() {
+    self.continueAfterFailure = false
+  }
+
   func testSwitchesConversationWhenSelectingRosterItem() {
     let app = XCUIApplication.launching(testCase: "roster-selection")
 


### PR DESCRIPTION
This PR adds support for sending and receiving message reactions as well as retracting messages. It also fixes the broken unit and UI tests.

I've updated the use of Character for reactions with a custom Reactions struct for future compatibility. I'm assuming that at some point we'll allow people their own emojis. It also makes the intent clearer in call sites especially when calling into closures where we don't have argument labels.