### PR TITLE
Message carbons

### DIFF
--- a/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,17 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "4cf088c29a20f52be0f2ca54992b492c54e0076b",
-        "version" : "0.5.3"
-      }
-    },
-    {
-      "identity" : "prose-wrapper-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/prose-im/prose-wrapper-swift",
-      "state" : {
-        "branch" : "0.2.0",
-        "revision" : "275120fb0efd09a6cdb861e1a342dd7ddfb18a39"
+        "revision" : "f7c8277f05f27a5bfb2f6ecccb0bad126ffcf472",
+        "version" : "0.7.0"
       }
     },
     {
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "cfcf8b43adc7d521a8ed26992d7ad8b979d386d2",
-        "version" : "0.37.0"
+        "revision" : "108e3a536fcebb16c4f247ef92c2d7326baf9fe3",
+        "version" : "0.39.0"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "2694c03284a368168b3e0b8d7ab52626802d2246",
-        "version" : "0.1.0"
+        "revision" : "7191be709528b0d0040105c7071d35fbb923d462",
+        "version" : "0.2.0"
       }
     },
     {
@@ -95,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
-        "version" : "0.2.1"
+        "revision" : "38bc9242e4388b80bd23ddfdf3071428859e3260",
+        "version" : "0.4.0"
       }
     }
   ],

--- a/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/prose-im/prose-wrapper-swift",
       "state" : {
-        "branch" : "0.1.9",
-        "revision" : "2c90f5148d00808f41279d607da97e5eb8cef5e5"
+        "branch" : "0.2.0",
+        "revision" : "275120fb0efd09a6cdb861e1a342dd7ddfb18a39"
+      }
+    },
+    {
+      "identity" : "prose-wrapper-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/prose-im/prose-wrapper-swift",
+      "state" : {
+        "branch" : "0.2.0",
+        "revision" : "275120fb0efd09a6cdb861e1a342dd7ddfb18a39"
       }
     },
     {

--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
       .upToNextMajor(from: "0.1.0")
     ),
     .package(url: "https://github.com/pointfreeco/swift-tagged", .upToNextMajor(from: "0.7.0")),
-    .proseCore("0.1.9"),
+    .proseCore("0.2.0"),
   ],
   targets: [
     .target(

--- a/Prose/ProseLib/Sources/ProseCore/ProseClient.swift
+++ b/Prose/ProseLib/Sources/ProseCore/ProseClient.swift
@@ -20,13 +20,13 @@ public final class ProseClient: ProseClientProtocol {
   private var isConnected = false
   private var loadMessagesCompletionHandlers = [String: LoadMessagesCompletionHandler]()
 
-  public var jid: BareJid {
+  public var jid: FullJid {
     self.client.jid()
   }
 
   private var credential: Credential?
 
-  public init(jid: BareJid, delegate: ProseClientDelegate, delegateQueue: DispatchQueue) {
+  public init(jid: FullJid, delegate: ProseClientDelegate, delegateQueue: DispatchQueue) {
     self.client = .init(jid: jid)
     self.delegate = delegate
     self.delegateQueue = delegateQueue
@@ -153,6 +153,18 @@ extension ProseClient: XmppAccountObserver {
   public func didReceiveMessage(message: XmppMessage) {
     self.callDelegateOnQueue { delegate in
       delegate.proseClient(self, didReceiveMessage: message)
+    }
+  }
+
+  public func didReceiveMessageCarbon(message: XmppForwardedMessage) {
+    self.callDelegateOnQueue { delegate in
+      delegate.proseClient(self, didReceiveMessageCarbon: message)
+    }
+  }
+
+  public func didReceiveSentMessageCarbon(message: XmppForwardedMessage) {
+    self.callDelegateOnQueue { delegate in
+      delegate.proseClient(self, didReceiveSentMessageCarbon: message)
     }
   }
 

--- a/Prose/ProseLib/Sources/ProseCore/ProseClientProtocol.swift
+++ b/Prose/ProseLib/Sources/ProseCore/ProseClientProtocol.swift
@@ -7,13 +7,13 @@ import Foundation
 import ProseCoreClientFFI
 
 public typealias ProseClientProvider<Client: ProseClientProtocol> =
-  (BareJid, ProseClientDelegate, DispatchQueue) -> Client
+  (FullJid, ProseClientDelegate, DispatchQueue) -> Client
 
 public typealias LoadMessagesCompletionHandler =
   (Result<[XmppForwardedMessage], Error>, _ isComplete: Bool) -> Void
 
 public protocol ProseClientProtocol: AnyObject {
-  var jid: BareJid { get }
+  var jid: FullJid { get }
 
   func connect(credential: Credential) throws
   func disconnect()
@@ -67,6 +67,14 @@ public protocol ProseClientDelegate: AnyObject {
   func proseClient(
     _ client: ProseClientProtocol,
     didReceiveMessage message: XmppMessage
+  )
+  func proseClient(
+    _ client: ProseClientProtocol,
+    didReceiveMessageCarbon message: XmppForwardedMessage
+  )
+  func proseClient(
+    _ client: ProseClientProtocol,
+    didReceiveSentMessageCarbon message: XmppForwardedMessage
   )
   func proseClient(
     _ client: ProseClientProtocol,

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
@@ -399,10 +399,10 @@ private extension Delegate {
     }
 
     if let reactions = message.reactions {
-      activeChats[from]?.updateMessage(id: Message.ID(rawValue: reactions.id)) { message in
-        message.reactions.setReactions(
+      activeChats[from]?.updateMessage(id: Message.ID(rawValue: reactions.id)) { messageToUpdate in
+        messageToUpdate.reactions.setReactions(
           reactions.reactions.map(Reaction.init(rawValue:)),
-          for: message.from
+          for: JID(bareJid: message.from)
         )
       }
     }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
@@ -401,7 +401,7 @@ private extension Delegate {
     if let reactions = message.reactions {
       activeChats[from]?.updateMessage(id: Message.ID(rawValue: reactions.id)) { message in
         message.reactions.setReactions(
-          Set(reactions.reactions.map(Reaction.init(rawValue:))),
+          reactions.reactions.map(Reaction.init(rawValue:)),
           for: message.from
         )
       }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient+Live.swift
@@ -393,7 +393,7 @@ private extension Delegate {
       }
     }
 
-    if let chatState = message.chatState {
+    if let chatState = message.chatState, carbon != .sent {
       activeChats[from, default: Chat(jid: from)].participantStates[from] =
         .init(state: chatState, timestamp: self.date())
     }

--- a/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/ProseClient.swift
@@ -28,6 +28,8 @@ public struct ProseClient {
   public var presence: () -> Effect<[JID: Presence], EquatableError>
 
   /// Returns an Effect that publishes new messages as they arrive.
+  ///
+  /// The messages published by this Effect do not include any message carbons.
   public var incomingMessages: () -> Effect<Message, Never>
 
   /// This will probably be split up in two methods/publishers. One where we can load older

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/JID.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/JID.swift
@@ -15,6 +15,10 @@ public extension JID {
   init(string: String) throws {
     self.bareJid = try ProseCoreClientFFI.parseJid(jid: string)
   }
+
+  init(fullJid: FullJid) {
+    self.bareJid = .init(node: fullJid.node, domain: fullJid.domain)
+  }
 }
 
 extension JID: RawRepresentable {

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -193,3 +193,13 @@ extension MessageReactions: Encodable {
     }
   }
 }
+
+extension MessageReactions: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    var lines = [String]()
+    for (reaction, authors) in self.reactions {
+      lines.append("\(reaction): [\(authors.map(\.rawValue).joined(separator: ","))]")
+    }
+    return "[\(lines.joined(separator: ","))]"
+  }
+}

--- a/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
+++ b/Prose/ProseLib/Sources/ProseCoreTCA/Types/Message.swift
@@ -148,8 +148,10 @@ public struct MessageReactions: Equatable {
     self.reactions.prose_toggle(jid, forKey: reaction)
   }
 
-  public mutating func setReactions(_ reactions: Set<Reaction>, for jid: JID) {
-    for reaction in self.reactions.keys where !reactions.contains(reaction) {
+  public mutating func setReactions(_ reactions: [Reaction], for jid: JID) {
+    let updatedReactions = Set(reactions)
+
+    for reaction in self.reactions.keys where !updatedReactions.contains(reaction) {
       self.reactions[reaction]?.remove(jid)
       // Remove key if the set is now empty
       if self.reactions[reaction]?.isEmpty == true {

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/ProseMockClient.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/Helpers/ProseMockClient.swift
@@ -8,12 +8,12 @@ import ProseCore
 import ProseCoreClientFFI
 
 final class ProseMockClient: ProseClientProtocol {
-  let jid: BareJid
+  let jid: FullJid
   let delegate: ProseClientDelegate
 
   var impl = ProseMockClientImpl()
 
-  init(jid: BareJid, delegate: ProseCore.ProseClientDelegate) {
+  init(jid: FullJid, delegate: ProseCore.ProseClientDelegate) {
     self.jid = jid
     self.delegate = delegate
   }

--- a/Prose/ProseLib/Tests/ProseCoreTCATests/ProseClientTests.swift
+++ b/Prose/ProseLib/Tests/ProseCoreTCATests/ProseClientTests.swift
@@ -506,7 +506,7 @@ final class ProseClientTests: XCTestCase {
         from: "chat1@prose.org",
         id: "3",
         body: nil,
-        reactions: .init(id: "1", reactions: ["🍻", "🐇"])
+        reactions: .init(id: "1", reactions: ["🍻", "🐇", "😇", "😘", "🤓", "😎"])
       )
     )
 
@@ -525,7 +525,14 @@ final class ProseClientTests: XCTestCase {
         ],
         [
           "00000000-0000-0000-0000-000000000000": ["❤️": ["marc@prose.org"]],
-          "1": ["🐇": ["chat1@prose.org"], "🍻": ["chat1@prose.org"]],
+          "1": [
+            "🍻": ["chat1@prose.org"],
+            "🐇": ["chat1@prose.org"],
+            "😇": ["chat1@prose.org"],
+            "😘": ["chat1@prose.org"],
+            "🤓": ["chat1@prose.org"],
+            "😎": ["chat1@prose.org"],
+          ],
         ],
       ]
     )


### PR DESCRIPTION
This PR adds support for message carbons as mentioned in #46.

That means that if you send or receive a message from or to another client that is logged into the same account, the Prose client will display the message as well but not show a notification for it.