### PR TITLE
chore: Fix warning (non-optional value compared to `nil`)

### DIFF
--- a/Prose/Prose.xcodeproj/project.pbxproj
+++ b/Prose/Prose.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2CBFFE79287D7D2B00A53992 /* RosterSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBFFE78287D7D2B00A53992 /* RosterSelectionTests.swift */; };
 		2CF10E9D287D8D0B0006DCFF /* UITestHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF10E9C287D8D0B0006DCFF /* UITestHostApp.swift */; };
 		2CF8F62D299F88A6002D5A11 /* App in Frameworks */ = {isa = PBXBuildFile; productRef = 2CF8F62C299F88A6002D5A11 /* App */; };
+		465B25BE2A26208B00217174 /* ConversationInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465B25BD2A26208B00217174 /* ConversationInfoTests.swift */; };
 		46A46C7428635B8E00F27E40 /* ConversationFeaturePreviewApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A46C7328635B8E00F27E40 /* ConversationFeaturePreviewApp.swift */; };
 		46A46C7628635B8E00F27E40 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A46C7528635B8E00F27E40 /* ContentView.swift */; };
 		46A46C7828635B9000F27E40 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 46A46C7728635B9000F27E40 /* Assets.xcassets */; };
@@ -60,6 +61,7 @@
 		2CBFFE76287D7D1900A53992 /* XCUIApplication+Prose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Prose.swift"; sourceTree = "<group>"; };
 		2CBFFE78287D7D2B00A53992 /* RosterSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosterSelectionTests.swift; sourceTree = "<group>"; };
 		2CF10E9C287D8D0B0006DCFF /* UITestHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHostApp.swift; sourceTree = "<group>"; };
+		465B25BD2A26208B00217174 /* ConversationInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationInfoTests.swift; sourceTree = "<group>"; };
 		46A46C7128635B8E00F27E40 /* ConversationFeaturePreview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ConversationFeaturePreview.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		46A46C7328635B8E00F27E40 /* ConversationFeaturePreviewApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFeaturePreviewApp.swift; sourceTree = "<group>"; };
 		46A46C7528635B8E00F27E40 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 			isa = PBXGroup;
 			children = (
 				2CBFFE78287D7D2B00A53992 /* RosterSelectionTests.swift */,
+				465B25BD2A26208B00217174 /* ConversationInfoTests.swift */,
 				2CBFFE7A287D7D3400A53992 /* Helpers */,
 			);
 			path = ProseUITests;
@@ -466,6 +469,7 @@
 			files = (
 				2CBFFE79287D7D2B00A53992 /* RosterSelectionTests.swift in Sources */,
 				2CBFFE77287D7D1900A53992 /* XCUIApplication+Prose.swift in Sources */,
+				465B25BE2A26208B00217174 /* ConversationInfoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Prose/ProseLib/Sources/ConversationFeature/ConversationScreenReducer.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/ConversationScreenReducer.swift
@@ -164,12 +164,6 @@ public struct ConversationScreenReducer: ReducerProtocol {
         )
         return .none
 
-      case .toolbar(.toggleInfoButtonTapped):
-        if state.toolbar.isShowingInfo, state.info == nil {
-          state.info = .init()
-        }
-        return .none
-
       case .event(.composingUsersChanged):
         return .task { [accountId = state.selectedAccountId, chatId = state.childState.chatId] in
           await .composingUsersResult(TaskResult {

--- a/Prose/ProseLib/Sources/ConversationFeature/InfoSidebar/ConversationInfoView.swift
+++ b/Prose/ProseLib/Sources/ConversationFeature/InfoSidebar/ConversationInfoView.swift
@@ -59,6 +59,7 @@ struct ConversationInfoView: View {
     .background(.background)
     .onAppear { self.viewStore.send(.onAppear) }
     .onDisappear { self.viewStore.send(.onDisappear) }
+    .accessibilityIdentifier("ConversationInfo")
   }
 
   var identitySection: some View {

--- a/Prose/ProseLib/Sources/ProseUI/OnlineStatusIndicator.swift
+++ b/Prose/ProseLib/Sources/ProseUI/OnlineStatusIndicator.swift
@@ -17,5 +17,9 @@ public struct OnlineStatusIndicator: View {
   public var body: some View {
     LEDIndicator(isOn: self.availability != .unavailable)
       .fillColor(self.availability == .available ? Colors.State.green.color : Color.orange)
+      // Override `LEDIndicator` accessibility label as it says "on"/"off"
+      .accessibilityElement(children: .ignore)
+      // FIXME: Localize ProseCoreFFI.Availability
+      .accessibilityLabel(String(describing: self.availability))
   }
 }

--- a/Prose/ProseLib/Sources/TestHostApp/Helpers/TestScene.swift
+++ b/Prose/ProseLib/Sources/TestHostApp/Helpers/TestScene.swift
@@ -20,6 +20,9 @@ public struct TestScene: Scene {
         case "roster-selection":
           RosterSelection()
 
+        case "conversation-info":
+          RosterSelection()
+
         default:
           Text("""
           Missing or unknown test case.

--- a/Prose/ProseUITests/ConversationInfoTests.swift
+++ b/Prose/ProseUITests/ConversationInfoTests.swift
@@ -1,0 +1,37 @@
+//
+// This file is part of prose-app-macos.
+// Copyright (c) 2023 Prose Foundation
+//
+
+import Foundation
+import XCTest
+
+final class ConversationInfoTests: XCTestCase {
+  override func setUp() {
+    self.continueAfterFailure = false
+  }
+
+  func testInfoChangesWhenSwitchingConversation() {
+    let app = XCUIApplication.launching(testCase: "conversation-info")
+
+    app.sidebar.cells
+      .containing(.staticText, identifier: "Oya Karaböcek").element.tap()
+
+    app.toolbars.checkBoxes["Info"].tap()
+
+    XCTAssertTrue(
+      app.conversationInfo.otherElements["Oya Karaböcek, available"]
+        .waitForExistence(timeout: 5)
+    )
+
+    app.sidebar.cells
+      .containing(.staticText, identifier: "Donna Reed").element.tap()
+
+    app.toolbars.checkBoxes["Info"].tap()
+
+    XCTAssertTrue(
+      app.conversationInfo.otherElements["Donna Reed, available"]
+        .waitForExistence(timeout: 5)
+    )
+  }
+}

--- a/Prose/ProseUITests/Helpers/XCUIApplication+Prose.swift
+++ b/Prose/ProseUITests/Helpers/XCUIApplication+Prose.swift
@@ -42,4 +42,8 @@ extension XCUIApplication {
   var chatWebView: XCUIElement {
     self.groups["ChatWebView"].webViews.firstMatch
   }
+
+  var conversationInfo: XCUIElement {
+    self.scrollViews["ConversationInfo"]
+  }
 }


### PR DESCRIPTION
While building the app, I got:

```log
Comparing non-optional value of type 'ConversationInfoReducer.State' (aka 'ChatSessionState<ConversationInfoReducer.ConversationInfoState>') to 'nil' always returns false
```

Now that `info` is initialized when the state is created, I don't think this code is necessary at all anymore. It may be useful when switching between conversations, we must try this before merging (hence the Draft status). I couldn't try locally because of #129, so can one of you confirm it doesn't break anything?