### PR TITLE
fix: Fix login popovers text color

### DIFF
--- a/Prose/ProseLib/Sources/AuthenticationFeature/BasicAuth/BasicAuthView.swift
+++ b/Prose/ProseLib/Sources/AuthenticationFeature/BasicAuth/BasicAuthView.swift
@@ -108,6 +108,7 @@ struct PopoverGroupBoxStyle: GroupBoxStyle {
       configuration.content
     }
     .font(.body)
+    .foregroundColor(.primary)
     .scaledToFit()
     .multilineTextAlignment(.leading)
     .padding(16)


### PR DESCRIPTION
I guess SwiftUI changed and now popovers (correctly) get the parent's `foregroundColor`.
We did not cover this case in the login screen so I fixed it.

Before:

<img width="400" alt="Screenshot 2023-05-30 at 15 04 35" src="https://github.com/prose-im/prose-app-macos/assets/37386490/e2d4ec69-63b0-4063-ba77-e23a52bbaf28">
<img width="400" alt="Screenshot 2023-05-30 at 15 04 43" src="https://github.com/prose-im/prose-app-macos/assets/37386490/ab85bc53-16b2-4e19-ac07-c5ccc0c0c289">

After:

<img width="400" alt="Screenshot 2023-05-30 at 15 06 43" src="https://github.com/prose-im/prose-app-macos/assets/37386490/30350355-c7e5-482c-8a8e-eba7bd857fba">
<img width="400" alt="Screenshot 2023-05-30 at 15 06 53" src="https://github.com/prose-im/prose-app-macos/assets/37386490/09d04d1a-de89-4ddc-82b2-258e66f11bd2">

Note: I didn't search for other occurrences as I can't log in.
