### PR TITLE
chore: Automate the creation of the "Previews" library

### DIFF
--- a/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Prose/Prose.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
+        "revision" : "0625932976b3ae23949f6b816d13bd97f3b40b7c",
+        "version" : "0.10.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "f9acfa1a45f4483fe0f2c434a74e6f68f865d12d",
+        "version" : "0.3.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "98650d886ec950b587d671261f06d6b59dec4052",
-        "version" : "0.4.1"
+        "revision" : "de1a984a71e51f6e488e98ce3652035563eb8acb",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Prose/ProseLib/Package.swift
+++ b/Prose/ProseLib/Package.swift
@@ -12,20 +12,6 @@ let package = Package(
     .library(name: "ConversationFeature", targets: ["ConversationFeature"]),
     .library(name: "Mocks", targets: ["Mocks"]),
     .library(name: "TestHostApp", targets: ["TestHostApp"]),
-    // For efficiency, Xcode doesn't build all targets when building for previews. This library does
-    // it.
-    .library(name: "Previews", targets: [
-      "AddressBookFeature",
-      "AuthenticationFeature",
-      "ConversationFeature",
-      "EditProfileFeature",
-      "JoinChatFeature",
-      "MainScreenFeature",
-      "ProseUI",
-      "SettingsFeature",
-      "SidebarFeature",
-      "UnreadFeature",
-    ]),
   ],
   dependencies: [
     .package(
@@ -199,7 +185,8 @@ extension PackageDescription.Target {
     dependencies: [Dependency] = [],
     exclude: [String] = []
   ) -> PackageDescription.Target {
-    self.target(
+    assert(name.hasSuffix("Feature"))
+    return self.target(
       name: name,
       dependencies: dependencies + [
         "AppDomain",
@@ -233,3 +220,23 @@ extension Array where Element == Target.Dependency {
     return self
   }
 }
+
+func addPreviewLibrary() {
+  var allFeatureTargets = Set<String>()
+
+  for target in package.targets {
+    if target.name.hasSuffix("Feature") {
+      allFeatureTargets.insert(target.name)
+    }
+  }
+
+  // For efficiency, Xcode doesn't build all targets when building for previews. This library does it.
+  package.products.append(.library(
+    name: "Previews",
+    targets: Array(allFeatureTargets) + [
+      "ProseUI",
+    ]
+  ))
+}
+
+addPreviewLibrary()


### PR DESCRIPTION
Having to maintain a list of targets is quite tedious, but we can automate its creation.